### PR TITLE
fix: Connection Instability with socketTimeout Parameter

### DIFF
--- a/lib/DataHandler.ts
+++ b/lib/DataHandler.ts
@@ -56,9 +56,13 @@ export default class DataHandler {
       },
     });
 
-    redis.stream.on("data", (data) => {
+    redis.stream.prependListener("data", (data) => {
       parser.execute(data);
     });
+
+    // `prependListener` not switching a stream to flowing mode as `on` does,
+    // so we need to do it manually in case if our listener is the first one
+    redis.stream.resume();
   }
 
   private returnFatalError(err: Error) {

--- a/test/functional/socketTimeout.ts
+++ b/test/functional/socketTimeout.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import Redis from "../../lib/Redis";
+
+describe("socketTimeout", () => {
+  const timeoutMs = 500;
+
+  it("should ensure correct startup with password (https://github.com/redis/ioredis/issues/1919)", (done) => {
+    let timeoutObj: NodeJS.Timeout;
+
+    const redis = new Redis({
+      socketTimeout: timeoutMs,
+      lazyConnect: true,
+      password: "foobared",
+    });
+
+    redis.on("error", (err) => {
+      clearTimeout(timeoutObj);
+      done(err.toString());
+    });
+
+    redis.connect(() => {
+      timeoutObj = setTimeout(() => {
+        done();
+      }, timeoutMs * 2);
+    });
+  });
+
+  it("should not throw error when socketTimeout is set and no command is sent", (done) => {
+    let timeoutObj: NodeJS.Timeout;
+
+    const redis = new Redis({
+      socketTimeout: timeoutMs,
+      lazyConnect: true,
+    });
+
+    redis.on("error", (err) => {
+      clearTimeout(timeoutObj);
+      done(err.toString());
+    });
+
+    redis.connect(() => {
+      timeoutObj = setTimeout(() => {
+        done();
+      }, timeoutMs * 2);
+    });
+  });
+
+  it("should throw if socket timeout is reached", (done) => {
+    const redis = new Redis({
+      socketTimeout: timeoutMs,
+      lazyConnect: true,
+    });
+
+    redis.on("error", (err) => {
+      expect(err.message).to.include("Socket timeout");
+      done();
+    });
+
+    redis.connect(() => {
+      redis.stream.removeAllListeners("data");
+      redis.ping();
+    });
+  });
+});

--- a/test/unit/DataHandler.ts
+++ b/test/unit/DataHandler.ts
@@ -1,0 +1,30 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import DataHandler from "../../lib/DataHandler";
+
+describe("DataHandler", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("constructor()", () => {
+    it("should add a data handler to the redis stream properly", () => {
+      const dataHandledable = {
+        stream: {
+          prependListener: sinon.spy(),
+          resume: sinon.spy(),
+        },
+      };
+      new DataHandler(dataHandledable, {});
+
+      expect(dataHandledable.stream.prependListener.calledOnce).to.eql(true);
+      expect(dataHandledable.stream.resume.calledOnce).to.eql(true);
+
+      expect(
+        dataHandledable.stream.resume.calledAfter(
+          dataHandledable.stream.prependListener
+        )
+      ).to.eql(true);
+    });
+  });
+});


### PR DESCRIPTION
This PR is fixing https://github.com/redis/ioredis/issues/1919 issue (When setting the `socketTimeout` parameter to a non-zero value, the Redis connection becomes unstable after startup)

--- 

The problem is that the `auth` command is sent before DataHandler is created on connection startup. This ruins the correct listener orders--the parser listener shall execute before the other ones.

To avoid this, I replaced `on` with `prependListener` to ensure the correct order. 
