### PR TITLE
feat: add noscores option

### DIFF
--- a/lib/ScanStream.ts
+++ b/lib/ScanStream.ts
@@ -4,6 +4,7 @@ interface Options extends ReadableOptions {
   key?: string;
   match?: string;
   type?: string;
+  noscores?: boolean;
   command: string;
   redis: any;
   count?: string | number;
@@ -38,6 +39,9 @@ export default class ScanStream extends Readable {
     }
     if (this.opt.count) {
       args.push("COUNT", String(this.opt.count));
+    }
+    if (this.opt.noscores) {
+      args.push("noscores");
     }
 
     this.opt.redis[this.opt.command](args, (err, res) => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,4 +30,5 @@ export interface ScanStreamOptions {
   match?: string;
   type?: string;
   count?: number;
+  noscores?: boolean;
 }

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -13801,6 +13801,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   zscan(
     key: RedisKey,
     cursor: number | string,
+    noscoresToken: "noscores",
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    noscoresToken: "noscores",
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
     countToken: "COUNT",
     count: number | string,
     callback?: Callback<[cursor: string, elements: string[]]>
@@ -13810,6 +13822,22 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
     cursor: number | string,
     countToken: "COUNT",
     count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    noscoresToken: "noscores",
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    noscoresToken: "noscores",
     callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
   ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
   zscan(
@@ -13831,6 +13859,22 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
     cursor: number | string,
     patternToken: "MATCH",
     pattern: string,
+    noscoresToken: "noscores",
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    noscoresToken: "noscores",
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
     countToken: "COUNT",
     count: number | string,
     callback?: Callback<[cursor: string, elements: string[]]>
@@ -13842,6 +13886,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
     pattern: string,
     countToken: "COUNT",
     count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    noscoresToken: "noscores",
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    noscoresToken: "noscores",
     callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
   ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 

--- a/test/functional/scripting.ts
+++ b/test/functional/scripting.ts
@@ -251,10 +251,10 @@ describe("scripting", () => {
       const [a, b] = await redis.multi().test("foo").test("bar").exec();
 
       expect(a[0].message).to.equal(
-        "NOSCRIPT No matching script. Please use EVAL."
+        "NOSCRIPT No matching script."
       );
       expect(b[0].message).to.equal(
-        "NOSCRIPT No matching script. Please use EVAL."
+        "NOSCRIPT No matching script."
       );
     });
     spy.restore();

--- a/test/unit/commander.ts
+++ b/test/unit/commander.ts
@@ -1,6 +1,7 @@
 import * as sinon from "sinon";
 import { expect } from "chai";
 import Commander from "../../lib/utils/Commander";
+import Command from "../../lib/Command";
 
 describe("Commander", () => {
   describe("#getBuiltinCommands()", () => {
@@ -62,5 +63,22 @@ describe("Commander", () => {
     expect(command.args.length).to.eql(2);
 
     Commander.prototype.sendCommand.restore();
+  });
+
+  describe("#zscan", () => {
+    it("should pass noscores option", async (done) => {
+      const args: any[] = ["key", "0", "MATCH", "pattern", "COUNT", "10", "noscores"];
+      sinon.stub(Commander.prototype, "sendCommand").callsFake((command) => {
+        if(command.args.every((arg, index) => arg === args[index])) {
+          return done();
+        }
+        console.error(command.args);
+        return done(new Error(`args should be ${args.join(", ")}`));
+      });
+      const c = new Commander();
+
+      await c.zscan(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+      (Commander.prototype.sendCommand as any).restore();
+    });
   });
 });


### PR DESCRIPTION
- Updated a zscan command ( noscores [doc](https://valkey.io/commands/zscan/) )
- Added an unit test for a new option
- Fixed a fail test
  The NOSCRIPT error message seems to have been changed in this [PR](https://github.com/valkey-io/valkey/pull/617)