### PR TITLE
chore: update repository url in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/valkey/iovalkey.git"
+    "url": "git://github.com/valkey-io/iovalkey.git"
   },
   "keywords": [
     "redis",


### PR DESCRIPTION
Currently, NPM package link on the website is broken (leads to 404):
<img width="410" alt="image" src="https://github.com/user-attachments/assets/ef859e48-090d-45ba-98f3-520e60bb186e">

Updating repo URL in the package.json should fix it on the next release/publish.