### PR TITLE
feat: Add ability for nat mapping through function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,42 @@ const cluster = new Valkey.Cluster(
 );
 ```
 
-This option is also useful when the cluster is running inside a Docker container.
+Or you can specify this parameter through function:
+```javascript
+const cluster = new Redis.Cluster(
+  [
+    {
+      host: "203.0.113.73",
+      port: 30001,
+    },
+  ],
+  {
+    natMap: (key) => {
+      if(key.indexOf('30001')) {
+        return { host: "203.0.113.73", port: 30001 };
+      }
+
+      return null;
+    },
+  }
+);
+```
+
+When is a dynamic natMap especially needed?
+- Dockerized Redis clusters where IPs change frequently.
+- Kubernetes-hosted Redis clusters with ephemeral Pods.
+- Cloud deployments where private subnets or NAT gateways are used for Redis communication where NAT mappings frequently change.
+- Scenarios with Redis node failover where failing nodes get replaced by new replicas and need rebalancing.
+
+Example of problem in a distributed Redis cluster with NAT in a Kubernetes environment:
+
+Your Redis client is configured to connect to 10.0.1.101:6379, but this is only accessible internally.
+The client uses static natMap to remap 10.0.1.101:6379 to 203.0.113.10:6379.
+A failure occurs, and the cluster rebalances, replacing 10.0.1.101:6379 with 10.0.1.105:6379.
+Without a function-based natMap, the static mapping is stale, and your client can no longer connect.
+With a function-based natMap, you dynamically fetch the new mapping for 10.0.1.105, ensuring continued access
+
+Specifying through may be useful if you don't know concrete internal host and know only node port.
 
 ### Transaction and Pipeline in Cluster Mode
 

--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ Your Redis client is configured to connect to 10.0.1.101:6379, but this is only 
 The client uses static natMap to remap 10.0.1.101:6379 to 203.0.113.10:6379.
 A failure occurs, and the cluster rebalances, replacing 10.0.1.101:6379 with 10.0.1.105:6379.
 Without a function-based natMap, the static mapping is stale, and your client can no longer connect.
-With a function-based natMap, you dynamically fetch the new mapping for 10.0.1.105, ensuring continued access
+With a function-based natMap, you dynamically fetch the new mapping for 10.0.1.105, ensuring continued access.
 
 Specifying through may be useful if you don't know concrete internal host and know only node port.
 

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -19,9 +19,11 @@ export type DNSLookupFunction = (
     family?: number
   ) => void
 ) => void;
-export interface NatMap {
+
+export type NatMapFunction = (key: string) => { host: string; port: number } | null;
+export type NatMap = {
   [key: string]: { host: string; port: number };
-}
+} | NatMapFunction
 
 /**
  * Options for Cluster constructor

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -787,17 +787,23 @@ class Cluster extends Commander {
   }
 
   private natMapper(nodeKey: NodeKey | RedisOptions): RedisOptions {
-    if (this.options.natMap && typeof this.options.natMap === "object") {
-      const key =
-        typeof nodeKey === "string"
-          ? nodeKey
-          : `${nodeKey.host}:${nodeKey.port}`;
-      const mapped = this.options.natMap[key];
-      if (mapped) {
-        debug("NAT mapping %s -> %O", key, mapped);
-        return Object.assign({}, mapped);
-      }
+    const key =
+      typeof nodeKey === "string"
+        ? nodeKey
+        : `${nodeKey.host}:${nodeKey.port}`;
+
+    let mapped = null;
+    if (this.options.natMap && typeof this.options.natMap === "function") {
+      mapped = this.options.natMap(key);
+    } else if (this.options.natMap && typeof this.options.natMap === "object") {
+      mapped = this.options.natMap[key];
     }
+
+    if (mapped) {
+      debug("NAT mapping %s -> %O", key, mapped);
+      return Object.assign({}, mapped);
+    }
+
     return typeof nodeKey === "string"
       ? nodeKeyToRedisOptions(nodeKey)
       : nodeKey;

--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -282,7 +282,16 @@ export default class SentinelConnector extends AbstractConnector {
   private sentinelNatResolve(item: SentinelAddress | null) {
     if (!item || !this.options.natMap) return item;
 
-    return this.options.natMap[`${item.host}:${item.port}`] || item;
+    const key = `${item.host}:${item.port}`;
+
+    let result = item;
+    if(typeof this.options.natMap === "function") {
+      result = this.options.natMap(key) || item;
+    } else if (typeof this.options.natMap === "object") {
+      result = this.options.natMap[key] || item;
+    }
+
+    return result;
   }
 
   private connectToSentinel(


### PR DESCRIPTION
The feature need when cluster nodes connected through dedicated subnet and you dont know exact host - only port
Also it would be useful if node failing and changing ip address

Changes:
- Extend NatMap Type - union with object(previous) and function
- Extend natMapper in Cluster for also work through function if it specified
- Extend sentinelNatResolve in SentinelConnector for also work through function if it specified

Maybe fixes: https://github.com/redis/ioredis/issues/1003