### PR TITLE
fix: handle non-existant redis node gracefully

### DIFF
--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -29,7 +29,7 @@ export default class ConnectionPool extends EventEmitter {
 
   getNodes(role: NodeRole = "all"): Redis[] {
     const nodeRecords = this.nodeRecords[role];
-    return Object.keys(nodeRecords).map((key) => nodeRecords[key].redis);
+    return Object.keys(nodeRecords).map((key) => nodeRecords[key]?.redis);
   }
 
   getInstanceByKey(key: NodeKey): Redis {
@@ -39,7 +39,7 @@ export default class ConnectionPool extends EventEmitter {
   getSampleInstance(role: NodeRole): Redis {
     const keys = Object.keys(this.nodeRecords[role]);
     const sampleKey = sample(keys);
-    return this.nodeRecords[role][sampleKey].redis;
+    return this.nodeRecords[role][sampleKey]?.redis;
   }
 
   /**

--- a/test/functional/cluster/ConnectionPool.ts
+++ b/test/functional/cluster/ConnectionPool.ts
@@ -1,0 +1,12 @@
+import { expect } from "chai";
+
+import ConnectionPool from "../../../lib/cluster/ConnectionPool";
+
+describe("The cluster connection pool", () => {
+  describe("when not connected", () => {
+    it("does not throw when fetching a sample node", () => {
+      expect(new ConnectionPool({}).getSampleInstance("all")).to.be.undefined;
+      expect(new ConnectionPool({}).getNodes("all")).to.be.eq([]);
+    });
+  });
+});

--- a/test/functional/cluster/ConnectionPool.ts
+++ b/test/functional/cluster/ConnectionPool.ts
@@ -6,7 +6,7 @@ describe("The cluster connection pool", () => {
   describe("when not connected", () => {
     it("does not throw when fetching a sample node", () => {
       expect(new ConnectionPool({}).getSampleInstance("all")).to.be.undefined;
-      expect(new ConnectionPool({}).getNodes("all")).to.be.eq([]);
+      expect(new ConnectionPool({}).getNodes("all")).to.be.eql([]);
     });
   });
 });


### PR DESCRIPTION
A bug introduced in https://github.com/valkey-io/iovalkey/pull/5 causes iovalkey to throw asynchronously from time to time **and crash the instance**

Before this change, if the affected methods could not find a node, they would return `undefined`; however, after the change, they immediately try to access the `redis` property even if the node doesn't exist at that time, which might happen for a variety of reasons

This is highly problematic as iovalkey runs timeout-based code periodically, and by their nature, it's very hard to catch them

Here's an example of the exception that will crash the instance:

```sh
TypeError: Cannot read properties of undefined (reading 'redis')
    at ConnectionPool.getSampleInstance (/node_modules/iovalkey/built/cluster/ConnectionPool.js:31:50)
    at tryConnection (/node_modules/iovalkey/built/cluster/index.js:455:56)
    at DelayQueue.execute (/node_modules/iovalkey/built/cluster/DelayQueue.js:49:26)
    at /node_modules/iovalkey/built/cluster/DelayQueue.js:32:26
    at wrapper (/node_modules/iovalkey/built/cluster/index.js:301:17)
    at tryNode (/node_modules/iovalkey/built/cluster/index.js:309:24)
    at /node_modules/iovalkey/built/cluster/index.js:325:21
    at /node_modules/iovalkey/built/cluster/index.js:666:24
    at run (/node_modules/iovalkey/built/utils/index.js:116:22)
    at tryCatcher (/node_modules/standard-as-callback/built/utils.js:12:23)
```