### PR TITLE
AZAffinity & AZAffinityReplicasAndPrimary Implementation

### DIFF
--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -3,6 +3,8 @@ import { RedisOptions } from "../redis/RedisOptions";
 import { CommanderOptions } from "../utils/Commander";
 import { NodeRole } from "./util";
 
+export type AzAffinityStrategy = "AZAffinity" | "AZAffinityReplicasAndPrimary";
+
 export type DNSResolveSrvFunction = (
   hostname: string,
   callback: (
@@ -59,7 +61,15 @@ export interface ClusterOptions extends CommanderOptions {
    *
    * @default "master"
    */
-  scaleReads?: NodeRole | Function;
+  scaleReads?: NodeRole | AzAffinityStrategy | Function;
+
+  /**
+   * Availability zone where the client is running. Required when `scaleReads`
+   * is set to an AZ affinity strategy.
+   *
+   * @example "us-east-1a"
+   */
+  clientAz?: string;
 
   /**
    * When a MOVED or ASK error is received, client will redirect the

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -11,7 +11,23 @@ type NodeRecord = {
   redis: Redis;
   endListener: () => void;
   errorListener: (error: unknown) => void;
+  availabilityZone?: string | null;
+  availabilityZonePromise?: Promise<void>;
 };
+
+function parseAvailabilityZone(reply: unknown): string | null {
+  if (!Array.isArray(reply)) {
+    return null;
+  }
+
+  for (let i = 0; i + 1 < reply.length; i += 2) {
+    if (reply[i] === "availability_zone") {
+      return typeof reply[i + 1] === "string" ? reply[i + 1] : null;
+    }
+  }
+
+  return null;
+}
 
 export default class ConnectionPool extends EventEmitter {
   // master + slave = all
@@ -40,6 +56,45 @@ export default class ConnectionPool extends EventEmitter {
     const keys = Object.keys(this.nodeRecords[role]);
     const sampleKey = sample(keys);
     return this.nodeRecords[role][sampleKey]?.redis;
+  }
+
+  getAvailabilityZone(redis: Redis): string | null | undefined {
+    const key = getNodeKey(redis.options as RedisOptions);
+    return this.nodeRecords.all[key]?.availabilityZone;
+  }
+
+  areAvailabilityZonesReady(nodeKeys: NodeKey[]): boolean {
+    return nodeKeys.every((key) => {
+      const record = this.nodeRecords.all[key];
+      return Boolean(record) && record.availabilityZone !== undefined;
+    });
+  }
+
+  ensureAvailabilityZones(nodeKeys: NodeKey[]): Promise<void> {
+    const uniqueKeys = Array.from(new Set(nodeKeys));
+    return Promise.all(
+      uniqueKeys.map((key) => {
+        const record = this.nodeRecords.all[key];
+        if (!record) {
+          return Promise.reject(
+            new Error(`Node ${key} is not in the connection pool`)
+          );
+        }
+        return this.ensureAvailabilityZone(key, record);
+      })
+    ).then(() => undefined);
+  }
+
+  prepareAvailabilityZones(nodes: RedisOptions[]): Promise<void> {
+    const nodeKeys = nodes.map((node) => {
+      const key = getNodeKey(node);
+      if (!this.nodeRecords.all[key]) {
+        this.findOrCreate(node, node.readOnly);
+      }
+      return key;
+    });
+
+    return this.ensureAvailabilityZones(nodeKeys);
   }
 
   /**
@@ -186,5 +241,38 @@ export default class ConnectionPool extends EventEmitter {
         this.emit("drain");
       }
     }
+  }
+
+  private ensureAvailabilityZone(
+    key: NodeKey,
+    record: NodeRecord
+  ): Promise<void> {
+    if (record.availabilityZone !== undefined) {
+      return Promise.resolve();
+    }
+    if (record.availabilityZonePromise) {
+      return record.availabilityZonePromise;
+    }
+
+    record.availabilityZonePromise = record.redis
+      .call("hello", "2")
+      .then((reply) => {
+        record.availabilityZone = parseAvailabilityZone(reply);
+        debug(
+          "HELLO availability_zone for %s -> %s",
+          key,
+          record.availabilityZone ?? "unknown"
+        );
+      })
+      .catch((error: Error) => {
+        record.availabilityZone = null;
+        debug(
+          "Cannot fetch HELLO availability_zone for %s: %s",
+          key,
+          error.message
+        );
+      });
+
+    return record.availabilityZonePromise;
   }
 }

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -21,7 +21,11 @@ import {
 } from "../utils";
 import applyMixin from "../utils/applyMixin";
 import Commander from "../utils/Commander";
-import { ClusterOptions, DEFAULT_CLUSTER_OPTIONS } from "./ClusterOptions";
+import {
+  AzAffinityStrategy,
+  ClusterOptions,
+  DEFAULT_CLUSTER_OPTIONS,
+} from "./ClusterOptions";
 import ClusterSubscriber from "./ClusterSubscriber";
 import ConnectionPool from "./ConnectionPool";
 import DelayQueue from "./DelayQueue";
@@ -42,6 +46,14 @@ import Deque = require("denque");
 const debug = Debug("cluster");
 
 const REJECT_OVERWRITTEN_COMMANDS = new WeakSet<Command>();
+
+function isAzAffinityStrategy(
+  strategy: ClusterOptions["scaleReads"]
+): strategy is AzAffinityStrategy {
+  return (
+    strategy === "AZAffinity" || strategy === "AZAffinityReplicasAndPrimary"
+  );
+}
 
 type OfflineQueueItem = {
   command: Command;
@@ -133,12 +145,27 @@ class Cluster extends Commander {
     // validate options
     if (
       typeof this.options.scaleReads !== "function" &&
-      ["all", "master", "slave"].indexOf(this.options.scaleReads) === -1
+      [
+        "all",
+        "master",
+        "slave",
+        "AZAffinity",
+        "AZAffinityReplicasAndPrimary",
+      ].indexOf(this.options.scaleReads as string) === -1
     ) {
       throw new Error(
         'Invalid option scaleReads "' +
           this.options.scaleReads +
-          '". Expected "all", "master", "slave" or a custom function'
+          '". Expected "all", "master", "slave", "AZAffinity", "AZAffinityReplicasAndPrimary" or a custom function'
+      );
+    }
+
+    if (
+      isAzAffinityStrategy(this.options.scaleReads) &&
+      !this.options.clientAz
+    ) {
+      throw new Error(
+        `Option "clientAz" is required when scaleReads is "${this.options.scaleReads}"`
       );
     }
 
@@ -584,10 +611,36 @@ class Cluster extends Commander {
             return;
           }
         } else {
-          if (!random) {
+          if (!random || isAzAffinityStrategy(to)) {
             if (typeof targetSlot === "number" && _this.slots[targetSlot]) {
               const nodeKeys = _this.slots[targetSlot];
-              if (typeof to === "function") {
+              if (isAzAffinityStrategy(to) && !asking) {
+                const nodes = nodeKeys.map(
+                  (key, index) =>
+                    _this.connectionPool.getInstanceByKey(key) ||
+                    _this.connectionPool.findOrCreate(
+                      _this.natMapper(key),
+                      index > 0
+                    ).redis
+                );
+                const availabilityZoneNodeKeys = nodes.map((node) =>
+                  getNodeKey(node.options as RedisOptions)
+                );
+                if (
+                  !_this.connectionPool.areAvailabilityZonesReady(
+                    availabilityZoneNodeKeys
+                  )
+                ) {
+                  _this.connectionPool
+                    .ensureAvailabilityZones(availabilityZoneNodeKeys)
+                    .then(
+                      () => tryConnection(random, asking),
+                      (error) => command.reject(error)
+                    );
+                  return;
+                }
+                redis = _this.selectNodeByAz(nodes, nodes[0]);
+              } else if (typeof to === "function") {
                 const nodes = nodeKeys.map(function (key) {
                   return _this.connectionPool.getInstanceByKey(key);
                 });
@@ -624,11 +677,28 @@ class Cluster extends Commander {
             }
           }
           if (!redis) {
-            redis =
-              (typeof to === "function"
-                ? null
-                : _this.connectionPool.getSampleInstance(to)) ||
-              _this.connectionPool.getSampleInstance("all");
+            if (isAzAffinityStrategy(to)) {
+              const nodes = _this.connectionPool.getNodes();
+              const nodeKeys = nodes.map((node) =>
+                getNodeKey(node.options as RedisOptions)
+              );
+              if (!_this.connectionPool.areAvailabilityZonesReady(nodeKeys)) {
+                _this.connectionPool
+                  .ensureAvailabilityZones(nodeKeys)
+                  .then(
+                    () => tryConnection(random, asking),
+                    (error) => command.reject(error)
+                  );
+                return;
+              }
+              redis = _this.selectNodeByAz(nodes);
+            } else {
+              redis =
+                (typeof to === "function"
+                  ? null
+                  : _this.connectionPool.getSampleInstance(to)) ||
+                _this.connectionPool.getSampleInstance("all");
+            }
           }
         }
         if (node && !node.redis) {
@@ -900,6 +970,11 @@ class Cluster extends Commander {
           return;
         }
         const nodes: RedisOptions[] = [];
+        const slotRanges: Array<{
+          start: number;
+          end: number;
+          keys: NodeKey[];
+        }> = [];
 
         debug("cluster slots result count: %d", result.length);
 
@@ -930,32 +1005,93 @@ class Cluster extends Commander {
             keys
           );
 
-          for (let slot = slotRangeStart; slot <= slotRangeEnd; slot++) {
-            this.slots[slot] = keys;
-          }
+          slotRanges.push({ start: slotRangeStart, end: slotRangeEnd, keys });
         }
 
-        // Assign to each node keys a numeric value to make autopipeline comparison faster.
-        this._groupsIds = Object.create(null);
-        let j = 0;
-        for (let i = 0; i < 16384; i++) {
-          const target = (this.slots[i] || []).join(";");
-
-          if (!target.length) {
-            this._groupsBySlot[i] = undefined;
-            continue;
+        const finalizeTopology = () => {
+          if (
+            this.status === "disconnecting" ||
+            this.status === "close" ||
+            this.status === "end"
+          ) {
+            callback();
+            return;
           }
 
-          if (!this._groupsIds[target]) {
-            this._groupsIds[target] = ++j;
+          for (const range of slotRanges) {
+            for (let slot = range.start; slot <= range.end; slot++) {
+              this.slots[slot] = range.keys;
+            }
           }
 
-          this._groupsBySlot[i] = this._groupsIds[target];
+          // Assign to each node keys a numeric value to make autopipeline comparison faster.
+          this._groupsIds = Object.create(null);
+          let j = 0;
+          for (let i = 0; i < 16384; i++) {
+            const target = (this.slots[i] || []).join(";");
+
+            if (!target.length) {
+              this._groupsBySlot[i] = undefined;
+              continue;
+            }
+
+            if (!this._groupsIds[target]) {
+              this._groupsIds[target] = ++j;
+            }
+
+            this._groupsBySlot[i] = this._groupsIds[target];
+          }
+
+          this.connectionPool.reset(nodes);
+          callback();
+        };
+
+        if (isAzAffinityStrategy(this.options.scaleReads)) {
+          this.connectionPool
+            .prepareAvailabilityZones(nodes)
+            .then(finalizeTopology, callback);
+        } else {
+          finalizeTopology();
         }
-
-        this.connectionPool.reset(nodes);
-        callback();
       }, this.options.slotsRefreshTimeout)
+    );
+  }
+
+  private selectNodeByAz(
+    nodes: Array<Redis | undefined>,
+    primary?: Redis
+  ): Redis | undefined {
+    const availableNodes = nodes.filter(Boolean) as Redis[];
+    const primaries = primary
+      ? [primary]
+      : availableNodes.filter((node) => !node.options.readOnly);
+    const replicas = primary
+      ? availableNodes.filter((node) => node !== primary)
+      : availableNodes.filter((node) => node.options.readOnly);
+    const isLocal = (node: Redis) =>
+      this.connectionPool.getAvailabilityZone(node) === this.options.clientAz;
+    const localReplicas = replicas.filter(isLocal);
+    const remoteReplicas = replicas.filter((node) => !isLocal(node));
+    const localPrimaries = primaries.filter(isLocal);
+    const remotePrimaries = primaries.filter((node) => !isLocal(node));
+    const pickFirstAvailable = (...groups: Redis[][]) => {
+      for (const group of groups) {
+        if (group.length) {
+          return sample(group);
+        }
+      }
+      return undefined;
+    };
+
+    if (this.options.scaleReads === "AZAffinity") {
+      return pickFirstAvailable(localReplicas, remoteReplicas, primaries);
+    }
+
+    return pickFirstAvailable(
+      localReplicas,
+      localPrimaries,
+      remoteReplicas,
+      remotePrimaries
     );
   }
 

--- a/test/functional/cluster/index.ts
+++ b/test/functional/cluster/index.ts
@@ -298,6 +298,476 @@ describe("cluster", () => {
     });
   });
 
+  describe("AZ affinity scaleReads", () => {
+    describe("routing", () => {
+      const nodePorts = [30001, 30003, 30004];
+      let slotTable;
+      let zones;
+      let helloCalls: any[][];
+
+      beforeEach(() => {
+        slotTable = [
+          [0, 16383, ...nodePorts.map((port) => ["127.0.0.1", port])],
+        ];
+        zones = {
+          30001: "zone-b",
+          30003: "zone-a",
+          30004: "zone-b",
+        };
+        helloCalls = [];
+
+        nodePorts.forEach((port, index) => {
+          new MockServer(port, (argv) => {
+            const command = argv[0];
+            if (command === "cluster" && argv[1] === "SLOTS") {
+              return slotTable;
+            }
+            if (command === "hello") {
+              helloCalls.push(argv);
+              return [
+                "server",
+                "valkey",
+                "version",
+                "8.1.0",
+                "proto",
+                2,
+                "id",
+                port,
+                "mode",
+                "cluster",
+                "role",
+                index === 0 ? "master" : "slave",
+                "modules",
+                [],
+                "availability_zone",
+                zones[port],
+              ];
+            }
+            return port;
+          });
+        });
+      });
+
+      context("AZAffinity", () => {
+        it("uses HELLO 2 and routes reads to a local replica", (done) => {
+          const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+            scaleReads: "AZAffinity",
+            clientAz: "zone-a",
+          });
+          cluster.on("ready", () => {
+            cluster.get("foo", (err, result) => {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30003);
+              expect(helloCalls).to.have.lengthOf(3);
+              helloCalls.forEach((argv) => expect(argv[1]).to.eql("2"));
+              cluster.disconnect();
+              done();
+            });
+          });
+        });
+
+        it("falls back to a remote replica", (done) => {
+          slotTable = [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30003]]];
+          zones[30001] = "zone-a";
+          zones[30003] = "zone-b";
+
+          const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+            scaleReads: "AZAffinity",
+            clientAz: "zone-a",
+          });
+          cluster.on("ready", () => {
+            cluster.get("foo", (err, result) => {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30003);
+              cluster.disconnect();
+              done();
+            });
+          });
+        });
+
+        it("falls back to the primary without replicas", (done) => {
+          slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+
+          const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+            scaleReads: "AZAffinity",
+            clientAz: "zone-a",
+          });
+          cluster.on("ready", () => {
+            cluster.get("foo", (err, result) => {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30001);
+              cluster.disconnect();
+              done();
+            });
+          });
+        });
+      });
+
+      context("AZAffinityReplicasAndPrimary", () => {
+        it("prefers a local replica", (done) => {
+          slotTable = [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30003]]];
+          zones[30001] = "zone-a";
+
+          const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+            scaleReads: "AZAffinityReplicasAndPrimary",
+            clientAz: "zone-a",
+          });
+          cluster.on("ready", () => {
+            cluster.get("foo", (err, result) => {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30003);
+              cluster.disconnect();
+              done();
+            });
+          });
+        });
+
+        it("prefers a local primary", (done) => {
+          slotTable = [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30003]]];
+          zones[30001] = "zone-a";
+          zones[30003] = "zone-b";
+
+          const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+            scaleReads: "AZAffinityReplicasAndPrimary",
+            clientAz: "zone-a",
+          });
+          cluster.on("ready", () => {
+            cluster.get("foo", (err, result) => {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30001);
+              cluster.disconnect();
+              done();
+            });
+          });
+        });
+
+        it("falls back to a remote replica", (done) => {
+          slotTable = [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30003]]];
+          zones[30001] = "zone-b";
+          zones[30003] = "zone-b";
+
+          const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+            scaleReads: "AZAffinityReplicasAndPrimary",
+            clientAz: "zone-a",
+          });
+          cluster.on("ready", () => {
+            cluster.get("foo", (err, result) => {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30003);
+              cluster.disconnect();
+              done();
+            });
+          });
+        });
+
+        it("falls back to a remote primary without replicas", (done) => {
+          slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+          zones[30001] = "zone-b";
+
+          const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+            scaleReads: "AZAffinityReplicasAndPrimary",
+            clientAz: "zone-a",
+          });
+          cluster.on("ready", () => {
+            cluster.get("foo", (err, result) => {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30001);
+              cluster.disconnect();
+              done();
+            });
+          });
+        });
+      });
+
+      it("samples only matching local replicas", (done) => {
+        zones[30004] = "zone-a";
+
+        const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+          scaleReads: "AZAffinity",
+          clientAz: "zone-a",
+        });
+        cluster.on("ready", () => {
+          const stub = sinon
+            .stub(utils, "sample")
+            .callsFake((nodes: Redis[]) => {
+              expect(nodes.map((node) => node.options.port)).to.eql([
+                30003, 30004,
+              ]);
+              return nodes[1];
+            });
+          cluster.get("foo", (err, result) => {
+            try {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30004);
+              expect(stub.callCount).to.eql(1);
+              stub.restore();
+              cluster.disconnect();
+              done();
+            } catch (error) {
+              stub.restore();
+              cluster.disconnect();
+              done(error);
+            }
+          });
+        });
+      });
+
+      it("keeps writes on the primary", (done) => {
+        const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+          scaleReads: "AZAffinity",
+          clientAz: "zone-a",
+        });
+        cluster.on("ready", () => {
+          cluster.set("foo", "bar", (err, result) => {
+            try {
+              expect(err).to.eql(null);
+              expect(result).to.eql(30001);
+              cluster.disconnect();
+              done();
+            } catch (error) {
+              cluster.disconnect();
+              done(error);
+            }
+          });
+        });
+      });
+    });
+
+    it("treats a missing availability_zone as a non-local fallback", (done) => {
+      new MockServer(30001, (argv) => {
+        const command = argv[0];
+        if (command === "cluster" && argv[1] === "SLOTS") {
+          return [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30004]]];
+        }
+        if (command === "hello") {
+          return [
+            "server",
+            "valkey",
+            "version",
+            "8.1.0",
+            "proto",
+            2,
+            "role",
+            "master",
+            "availability_zone",
+            "zone-a",
+          ];
+        }
+        return 30001;
+      });
+      new MockServer(30004, (argv) => {
+        const command = argv[0];
+        if (command === "hello") {
+          // Simulate a server whose HELLO reply omits the field entirely
+          // (e.g. a server that predates availability-zone support).
+          return [
+            "server",
+            "valkey",
+            "version",
+            "7.2.0",
+            "proto",
+            2,
+            "role",
+            "slave",
+          ];
+        }
+        return 30004;
+      });
+
+      const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+        scaleReads: "AZAffinityReplicasAndPrimary",
+        clientAz: "zone-a",
+      });
+      cluster.on("ready", () => {
+        cluster.get("foo", (err, result) => {
+          try {
+            expect(err).to.eql(null);
+            expect(result).to.eql(30001);
+            cluster.disconnect();
+            done();
+          } catch (error) {
+            cluster.disconnect();
+            done(error);
+          }
+        });
+      });
+    });
+
+    it("waits for all candidate metadata before becoming ready", (done) => {
+      const nodes = [
+        { port: 30001, zone: "zone-b" },
+        { port: 30003, zone: "zone-a" },
+        { port: 30004, zone: "zone-b" },
+      ];
+      const slotTable = [
+        [0, 16383, ...nodes.map((node) => ["127.0.0.1", node.port])],
+      ];
+      const pendingReplies: Array<{
+        server: MockServer;
+        socket: any;
+        reply: unknown;
+      }> = [];
+      let ready = false;
+
+      nodes.forEach((node, index) => {
+        let server: MockServer;
+        server = new MockServer(node.port, (argv, socket, flags) => {
+          const command = argv[0];
+          if (command === "cluster" && argv[1] === "SLOTS") {
+            return slotTable;
+          }
+          if (command === "hello") {
+            flags.hang = true;
+            pendingReplies.push({
+              server,
+              socket,
+              reply: [
+                "server",
+                "valkey",
+                "version",
+                "8.1.0",
+                "proto",
+                2,
+                "role",
+                index === 0 ? "master" : "slave",
+                "availability_zone",
+                node.zone,
+              ],
+            });
+            if (pendingReplies.length === nodes.length) {
+              setImmediate(() => {
+                try {
+                  expect(ready).to.eql(false);
+                  pendingReplies.forEach((pending) =>
+                    pending.server.write(pending.socket, pending.reply)
+                  );
+                } catch (error) {
+                  done(error);
+                }
+              });
+            }
+            return;
+          }
+          return node.port;
+        });
+      });
+
+      const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+        scaleReads: "AZAffinity",
+        clientAz: "zone-a",
+      });
+      cluster.once("ready", () => {
+        ready = true;
+        cluster.disconnect();
+        done();
+      });
+    });
+
+    it("keeps the previous topology active while new node metadata is pending", (done) => {
+      let slotTable = [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30003]]];
+      const nodes = [
+        { port: 30001, zone: "zone-a" },
+        { port: 30003, zone: "zone-b" },
+      ];
+
+      nodes.forEach((node, index) => {
+        new MockServer(node.port, (argv) => {
+          const command = argv[0];
+          if (command === "cluster" && argv[1] === "SLOTS") {
+            return slotTable;
+          }
+          if (command === "hello") {
+            return [
+              "server",
+              "valkey",
+              "version",
+              "8.1.0",
+              "proto",
+              2,
+              "role",
+              index === 0 ? "master" : "slave",
+              "availability_zone",
+              node.zone,
+            ];
+          }
+          return node.port;
+        });
+      });
+
+      let newNode: MockServer;
+      let metadataRequested = false;
+      newNode = new MockServer(30004, (argv, socket, flags) => {
+        const command = argv[0];
+        if (command === "cluster" && argv[1] === "SLOTS") {
+          return slotTable;
+        }
+        if (command === "hello") {
+          metadataRequested = true;
+          flags.hang = true;
+          setImmediate(() => {
+            try {
+              cluster.get("foo", (err, result) => {
+                try {
+                  expect(err).to.eql(null);
+                  expect(result).to.eql(30003);
+                  newNode.write(socket, [
+                    "server",
+                    "valkey",
+                    "version",
+                    "8.1.0",
+                    "proto",
+                    2,
+                    "role",
+                    "slave",
+                    "availability_zone",
+                    "zone-a",
+                  ]);
+                } catch (error) {
+                  done(error);
+                }
+              });
+            } catch (error) {
+              done(error);
+            }
+          });
+          return;
+        }
+        return 30004;
+      });
+
+      const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+        scaleReads: "AZAffinity",
+        clientAz: "zone-a",
+      });
+      cluster.once("ready", () => {
+        slotTable = [
+          [
+            0,
+            16383,
+            ["127.0.0.1", 30001],
+            ["127.0.0.1", 30003],
+            ["127.0.0.1", 30004],
+          ],
+        ];
+        cluster.once("refresh", () => {
+          cluster.get("foo", (err, result) => {
+            try {
+              expect(metadataRequested).to.eql(true);
+              expect(err).to.eql(null);
+              expect(result).to.eql(30004);
+              cluster.disconnect();
+              done();
+            } catch (error) {
+              cluster.disconnect();
+              done(error);
+            }
+          });
+        });
+        cluster.refreshSlotsCache();
+      });
+    });
+  });
+
   describe("#nodes()", () => {
     it("should return the current nodes", (done) => {
       const slotTable = [

--- a/test/functional/cluster/loading.ts
+++ b/test/functional/cluster/loading.ts
@@ -108,4 +108,65 @@ describe("cluster:LOADING", () => {
       done();
     });
   });
+
+  it("retries AZAffinity reads without treating the strategy as a pool role", (done) => {
+    let replicaReads = 0;
+    new MockServer(30001, (argv) => {
+      const command = argv[0];
+      if (command === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (command === "hello") {
+        return [
+          "server",
+          "valkey",
+          "version",
+          "8.1.0",
+          "proto",
+          2,
+          "role",
+          "master",
+          "availability_zone",
+          "zone-b",
+        ];
+      }
+      return "master";
+    });
+    new MockServer(30002, (argv) => {
+      const command = argv[0];
+      if (command === "hello") {
+        return [
+          "server",
+          "valkey",
+          "version",
+          "8.1.0",
+          "proto",
+          2,
+          "role",
+          "slave",
+          "availability_zone",
+          "zone-a",
+        ];
+      }
+      if (command === "get") {
+        if (replicaReads++ === 0) {
+          return new Error("LOADING Redis is loading the dataset in memory");
+        }
+        return "replica";
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      scaleReads: "AZAffinity",
+      clientAz: "zone-a",
+      retryDelayOnTryAgain: 1,
+    });
+    cluster.get("foo", (err, result) => {
+      expect(err).to.eql(null);
+      expect(result).to.eql("replica");
+      expect(replicaReads).to.eql(2);
+      cluster.disconnect();
+      done();
+    });
+  });
 });

--- a/test/typing/options.test-d.ts
+++ b/test/typing/options.test-d.ts
@@ -47,6 +47,18 @@ expectType<Cluster>(
     enableAutoPipelining: true,
   })
 );
+expectType<Cluster>(
+  new Redis.Cluster([30001, 30002], {
+    scaleReads: "AZAffinity",
+    clientAz: "us-east-1a",
+  })
+);
+expectType<Cluster>(
+  new Redis.Cluster([30001, 30002], {
+    scaleReads: "AZAffinityReplicasAndPrimary",
+    clientAz: "us-east-1a",
+  })
+);
 
 expectAssignable<NatMap>({
   "10.0.1.230:30001": { host: "203.0.113.73", port: 30001 },

--- a/test/unit/clusters/index.ts
+++ b/test/unit/clusters/index.ts
@@ -42,6 +42,43 @@ describe("cluster", () => {
     }).to.throw(/Invalid option scaleReads/);
   });
 
+  it("requires clientAz when scaleReads is AZAffinity", () => {
+    expect(() => new Cluster([{}], { scaleReads: "AZAffinity" })).to.throw(
+      /Option "clientAz" is required/
+    );
+  });
+
+  it("requires clientAz when scaleReads is AZAffinityReplicasAndPrimary", () => {
+    expect(
+      () =>
+        new Cluster([{}], {
+          scaleReads: "AZAffinityReplicasAndPrimary",
+        })
+    ).to.throw(/Option "clientAz" is required/);
+  });
+
+  it("accepts clientAz when scaleReads is AZAffinity", () => {
+    const cluster = new Cluster([{}], {
+      scaleReads: "AZAffinity",
+      clientAz: "zone-a",
+    });
+    expect(cluster.options).to.include({
+      scaleReads: "AZAffinity",
+      clientAz: "zone-a",
+    });
+  });
+
+  it("accepts clientAz when scaleReads is AZAffinityReplicasAndPrimary", () => {
+    const cluster = new Cluster([{}], {
+      scaleReads: "AZAffinityReplicasAndPrimary",
+      clientAz: "zone-a",
+    });
+    expect(cluster.options).to.include({
+      scaleReads: "AZAffinityReplicasAndPrimary",
+      clientAz: "zone-a",
+    });
+  });
+
   it("disables slotsRefreshTimeout by default", () => {
     const cluster = new Cluster([{}]);
     expect(cluster.options.slotsRefreshInterval).to.eql(undefined);


### PR DESCRIPTION
Fixes: https://github.com/valkey-io/iovalkey/issues/23
Implements support for AZAffinity and AZAffinityReplicasAndPrimary read strategies based on the [Valkey blog post on AZ Affinity](https://valkey.io/blog/az-affinity-strategy/).
Developers can now use:
`scaleReads: "AZAffinity" | "AZAffinityReplicasAndPrimary",
clientAz: "zone-a" // etc.
`
During Redis initialization, a HELLO 3 call is made to retrieve the availabilityZone, which is then saved under each node instance.
A new selectNodeAz method was introduced. This method is called internally when scaleReads is set to AZAffinity or AZAffinityReplicasAndPrimary. Based on the strategy, it routes commands to the most suitable node:
**AZAffinity logic:**
1. Prefer a replica in the same AZ
2. If not available, pick a replica from a different AZ
3. If none, fallback to master.

**AZAffinityReplicasAndPrimary logic:**
1. Prefer a replica in the same AZ
2. If not available, fallback to local master
3. Then to remote replica
4. Then to remote master

**Tests**
Tests were added to cover each of the above scenarios.
However, two tests sometimes pass and sometimes fail: 
I couldn't figure out exactly why this happens. I couldn’t find a solution
`AZAffinity → selects remote replica when no local replica exists`
`AZAffinityReplicasAndPrimary → selects local primary when no local replica exists`



and I’m unsure if I’ve placed the test logic in the best place,
 or if additional handling is needed in selectNodeAz or elsewhere