### PR TITLE
fix: clear socketTimeout timer on close so it can't destroy the reconnected socket

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -562,6 +562,24 @@ class Redis extends Commander implements DataHandledable {
     });
   }
 
+  /**
+   * Cancel any pending socket timeout timer.
+   *
+   * The timer is armed against a specific socket, but its callback destroys
+   * whatever `this.stream` points to when it fires. If the socket it was armed
+   * for closes before its `"data"` handler clears the timer (e.g. the
+   * connection drops with no reply in flight), the timer would otherwise
+   * survive the reconnect and destroy the new, healthy stream. Clearing it on
+   * close prevents that spurious disconnect and lets the next command re-arm a
+   * fresh timer on the current socket.
+   */
+  private clearSocketTimeout() {
+    if (this.socketTimeoutTimer !== undefined) {
+      clearTimeout(this.socketTimeoutTimer);
+      this.socketTimeoutTimer = undefined;
+    }
+  }
+
   scanStream(options?: ScanStreamOptions) {
     return this.createScanStream("scan", { options });
   }

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -157,6 +157,10 @@ function abortTransactionFragments(commandQueue: Deque<CommandItem>) {
 
 export function closeHandler(self) {
   return function () {
+    // Cancel any socket timeout armed on the closing socket so a stale timer
+    // can't destroy the next (healthy) stream after a reconnect.
+    self.clearSocketTimeout();
+
     const prevStatus = self.status;
     self.setStatus("close");
 

--- a/test/functional/socketTimeout.ts
+++ b/test/functional/socketTimeout.ts
@@ -61,4 +61,55 @@ describe("socketTimeout", () => {
       redis.ping();
     });
   });
+
+  it("should not destroy a healthy socket after reconnecting", (done) => {
+    // Arms the socketTimeout on the first socket, then drops that socket
+    // before any data clears the timer. The stale timer must not survive the
+    // reconnect and destroy the new, healthy socket.
+    const redis = new Redis({
+      socketTimeout: timeoutMs,
+      lazyConnect: true,
+    });
+
+    let readyCount = 0;
+    let settled = false;
+    let doneTimer: NodeJS.Timeout;
+
+    const finish = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(doneTimer);
+      redis.disconnect();
+      done(err);
+    };
+
+    redis.on("error", (err) => {
+      // A socket timeout after we've already reconnected means the stale timer
+      // destroyed the healthy socket — the bug we're guarding against.
+      if (readyCount >= 2 && String(err.message).includes("Socket timeout")) {
+        finish(
+          new Error(
+            "stale socketTimeout timer destroyed the reconnected socket"
+          )
+        );
+      }
+    });
+
+    redis.on("ready", () => {
+      readyCount++;
+      if (readyCount === 1) {
+        // Prevent the "data" handler from clearing the timer, arm it with a
+        // command, then kill the socket to force a reconnect.
+        redis.stream.removeAllListeners("data");
+        redis.ping().catch(() => {});
+        redis.stream.destroy();
+      } else if (readyCount === 2) {
+        // Wait past the socketTimeout window; if no spurious timeout fires on
+        // the healthy socket, the bug is fixed.
+        doneTimer = setTimeout(() => finish(), timeoutMs * 2);
+      }
+    });
+
+    redis.connect().catch(() => {});
+  });
 });


### PR DESCRIPTION
### Problem
When `socketTimeout` is set, the timer armed by `setSocketTimeout()` is only ever
cleared inside its own `stream.once("data")` handler. If the socket the timer was
armed for closes *before* any reply arrives (e.g. the connection drops with a
command in flight), that `"data"` handler never fires, so the timer is never cleared.

The timer callback runs `this.stream.destroy(...)` — and by the time it fires,
`this.stream` points to the **new socket created by the reconnect**. So a healthy,
freshly-reconnected socket is destroyed with a spurious
`Socket timeout. Expecting data...` error, triggering yet another reconnect.

There's a second effect: because a new timer is only armed when
`socketTimeoutTimer === undefined`, the stale timer also prevents the reconnected
socket from being monitored until it fires.

**Reproduction** (`socketTimeout: 1000`): send a command, drop the socket before any
reply, let the client reconnect — ~1000ms after the original command the stale timer
fires and destroys the healthy socket.

### Fix
Add `Redis#clearSocketTimeout()` and call it from `closeHandler`, which runs on every
socket close (wired via `stream.once("close", ...)`) before any reconnect. This cancels
the stale timer so the next command re-arms a fresh one on the current socket.

### Tests
Added a functional regression test that arms the timer, drops the socket to force a
reconnect, and asserts the healthy reconnected socket is not destroyed. Verified it
**fails on `main`** and **passes with this fix**. Existing `socketTimeout` tests still pass.
