### PR TITLE
fix(cluster): recover stale ElastiCache connections

### DIFF
--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -112,6 +112,32 @@ export default class ConnectionPool extends EventEmitter {
   }
 
   /**
+   * Replace a stale connection to a node with a fresh one.
+   */
+  recreate(redisOptions: RedisOptions, readOnly = false): NodeRecord {
+    const key = getNodeKey(redisOptions);
+    const existing = this.nodeRecords.all[key];
+
+    if (existing) {
+      debug("Recreating connection to %s", key);
+      existing.redis.removeListener("end", existing.endListener);
+      existing.redis.removeListener("error", existing.errorListener);
+      delete this.nodeRecords.all[key];
+      delete this.nodeRecords.master[key];
+      delete this.nodeRecords.slave[key];
+      existing.redis.disconnect();
+    }
+
+    const replacement = this.findOrCreate(redisOptions, readOnly);
+    if (existing) {
+      // Notify listeners only after the replacement is registered, so they
+      // never observe an empty pool during an atomic replacement.
+      this.emit("-node", existing.redis, key);
+    }
+    return replacement;
+  }
+
+  /**
    * Reset the pool with a set of nodes.
    * The old node will be removed.
    */

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -27,6 +27,7 @@ import ConnectionPool from "./ConnectionPool";
 import DelayQueue from "./DelayQueue";
 import {
   getConnectionName,
+  getNodeKey,
   getUniqueHostnamesFromOptions,
   groupSrvRecords,
   NodeKey,
@@ -488,6 +489,9 @@ class Cluster extends Commander {
     let targetSlot = node ? node.slot : command.getSlot();
     const ttl = {};
     const _this = this;
+    // Track the connection used for the previous attempt so circular MOVED
+    // responses can distinguish a stale connection from a normal redirect.
+    let lastRedis: Redis | null = null;
     if (!node && !REJECT_OVERWRITTEN_COMMANDS.has(command)) {
       REJECT_OVERWRITTEN_COMMANDS.add(command);
 
@@ -505,7 +509,24 @@ class Cluster extends Commander {
             }
             _this._groupsBySlot[slot] =
               _this._groupsIds[_this.slots[slot].join(";")];
-            _this.connectionPool.findOrCreate(_this.natMapper(key));
+            const mapped = _this.natMapper(key);
+            const mappedKey = getNodeKey(mapped);
+            if (
+              lastRedis &&
+              getNodeKey(lastRedis.options as RedisOptions) === mappedKey &&
+              _this.connectionPool.getInstanceByKey(mappedKey) === lastRedis
+            ) {
+              // A redirect back to the connection that returned it can loop
+              // forever when a proxy endpoint changes its backing server.
+              // Reconnect once; concurrent commands will reuse the replacement.
+              debug(
+                "MOVED redirect points back at %s; recreating its connection",
+                mappedKey
+              );
+              _this.connectionPool.recreate(mapped);
+            } else {
+              _this.connectionPool.findOrCreate(mapped);
+            }
             tryConnection();
             debug("refreshing slot caches... (triggered by MOVED error)");
             _this.refreshSlotsCache();
@@ -573,6 +594,14 @@ class Cluster extends Commander {
                   key = nodeKeys[0];
                 }
                 redis = _this.connectionPool.getInstanceByKey(key);
+                if (!redis) {
+                  // The slot map still owns this node, so recreate its lost
+                  // transport instead of falling back to an unrelated node.
+                  redis = _this.connectionPool.findOrCreate(
+                    _this.natMapper(key),
+                    nodeKeys.indexOf(key) > 0
+                  ).redis;
+                }
               }
             }
             if (asking) {
@@ -593,6 +622,7 @@ class Cluster extends Commander {
         }
       }
       if (redis) {
+        lastRedis = redis;
         redis.sendCommand(command, stream);
       } else if (_this.options.enableOfflineQueue) {
         _this.offlineQueue.push({

--- a/test/functional/cluster/moved.ts
+++ b/test/functional/cluster/moved.ts
@@ -76,6 +76,128 @@ describe("cluster:MOVED", () => {
     });
   });
 
+  it("reconnects a missing master instead of using the read-only port", (done) => {
+    const slotTable = [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30002]]];
+    let replicaWrites = 0;
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+    });
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "set") {
+        replicaWrites += 1;
+        return new Error(
+          "MOVED " + calculateSlot(argv[1]) + " 127.0.0.1:30001"
+        );
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+    cluster.on("ready", () => {
+      const master = cluster.nodes("master")[0];
+      cluster.once("-node", () => {
+        cluster.set("foo", "bar", (err, result) => {
+          expect(err).to.eql(null);
+          expect(result).to.eql("OK");
+          expect(replicaWrites).to.eql(0);
+          cluster.disconnect();
+          done();
+        });
+      });
+      master.stream.destroy();
+    });
+  });
+
+  it("recreates a stale connection on a circular MOVED", (done) => {
+    // Simulate a proxy whose backend changed while the pooled socket remained
+    // open. The stale socket redirects to its own endpoint; a fresh socket works.
+    const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+    let swapped = false;
+    let movedCount = 0;
+    const freshSockets = new Set();
+    const server = new MockServer(30001, (argv, socket) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        if (swapped && !freshSockets.has(socket)) {
+          movedCount += 1;
+          return new Error(
+            "MOVED " + calculateSlot("foo") + " 127.0.0.1:30001"
+          );
+        }
+        return "bar";
+      }
+    });
+    server.on("connect", (socket) => {
+      if (swapped) {
+        freshSockets.add(socket);
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+    cluster.get("foo", (err, result) => {
+      expect(err).to.eql(null);
+      expect(result).to.eql("bar");
+      swapped = true;
+
+      cluster.get("foo", (retryErr, retryResult) => {
+        expect(retryErr).to.eql(null);
+        expect(retryResult).to.eql("bar");
+        expect(movedCount).to.eql(1);
+        cluster.disconnect();
+        done();
+      });
+    });
+  });
+
+  it("recreates a stale connection only once for concurrent MOVEDs", (done) => {
+    const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+    let swapped = false;
+    const freshSockets = new Set();
+    const server = new MockServer(30001, (argv, socket) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        if (swapped && !freshSockets.has(socket)) {
+          return new Error(
+            "MOVED " + calculateSlot("foo") + " 127.0.0.1:30001"
+          );
+        }
+        return "bar";
+      }
+    });
+    server.on("connect", (socket) => {
+      if (swapped) {
+        freshSockets.add(socket);
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+    cluster.get("foo", (err, result) => {
+      expect(err).to.eql(null);
+      expect(result).to.eql("bar");
+      swapped = true;
+      const recreateSpy = sinon.spy(cluster.connectionPool, "recreate");
+
+      Promise.all([cluster.get("foo"), cluster.get("foo")]).then(
+        ([first, second]) => {
+          expect(first).to.eql("bar");
+          expect(second).to.eql("bar");
+          expect(recreateSpy.callCount).to.eql(1);
+          cluster.disconnect();
+          done();
+        },
+        done
+      );
+    });
+  });
+
   it("should auto redirect the command within a pipeline", (done) => {
     let cluster = undefined;
     let moved = false;

--- a/test/unit/clusters/ConnectionPool.ts
+++ b/test/unit/clusters/ConnectionPool.ts
@@ -3,6 +3,73 @@ import { expect } from "chai";
 import ConnectionPool from "../../../lib/cluster/ConnectionPool";
 
 describe("ConnectionPool", () => {
+  describe("#recreate", () => {
+    it("replaces the existing connection with a new instance", () => {
+      const pool = new ConnectionPool({});
+      const oldRecord = pool.findOrCreate({
+        host: "127.0.0.1",
+        port: 30001,
+      });
+      const disconnectStub = sinon.stub(oldRecord.redis, "disconnect");
+
+      const newRecord = pool.recreate({ host: "127.0.0.1", port: 30001 });
+
+      expect(disconnectStub.calledOnce).to.eql(true);
+      expect(newRecord.redis).to.not.equal(oldRecord.redis);
+      expect(pool.getInstanceByKey("127.0.0.1:30001")).to.equal(
+        newRecord.redis
+      );
+      expect(pool.getNodes()).to.have.lengthOf(1);
+    });
+
+    it("notifies listeners after registering the replacement", () => {
+      const pool = new ConnectionPool({});
+      const oldRecord = pool.findOrCreate({
+        host: "127.0.0.1",
+        port: 30001,
+      });
+      sinon.stub(oldRecord.redis, "disconnect");
+      let replacement;
+      const removeSpy = sinon.spy();
+
+      pool.on("+node", (redis) => {
+        replacement = redis;
+      });
+      pool.on("-node", () => {
+        removeSpy();
+        expect(pool.getInstanceByKey("127.0.0.1:30001")).to.equal(replacement);
+      });
+
+      const newRecord = pool.recreate({ host: "127.0.0.1", port: 30001 });
+      expect(replacement).to.equal(newRecord.redis);
+      expect(removeSpy.calledOnce).to.eql(true);
+    });
+
+    it("does not drain the pool while replacing the node", () => {
+      const pool = new ConnectionPool({});
+      const oldRecord = pool.findOrCreate({
+        host: "127.0.0.1",
+        port: 30001,
+      });
+      sinon.stub(oldRecord.redis, "disconnect");
+      const drainSpy = sinon.spy();
+      pool.on("drain", drainSpy);
+
+      pool.recreate({ host: "127.0.0.1", port: 30001 });
+      oldRecord.redis.emit("end");
+
+      expect(drainSpy.called).to.eql(false);
+      expect(pool.getNodes()).to.have.lengthOf(1);
+    });
+
+    it("creates a connection when the node is not in the pool", () => {
+      const pool = new ConnectionPool({});
+      const record = pool.recreate({ host: "127.0.0.1", port: 30001 });
+
+      expect(pool.getInstanceByKey("127.0.0.1:30001")).to.equal(record.redis);
+    });
+  });
+
   describe("#reset", () => {
     it("prefers to master if there are two same node for a slot", () => {
       const pool = new ConnectionPool({});


### PR DESCRIPTION
## Summary

- reconnect the slot owner when its pooled transport disappears instead of falling back to an unrelated read-only/RFR node
- recreate a stale connection when `MOVED` redirects back to the same endpoint, avoiding circular redirect loops after a proxy backend changes
- deduplicate concurrent circular-`MOVED` recovery and preserve connection-pool lifecycle notifications
- add unit and functional coverage for missing masters, stale proxy connections, and concurrent redirects

This covers both failure modes reported for ElastiCache Serverless: traffic falling through to port 6380 after the writable connection resets, and retries looping against a stale logical endpoint.

Related upstream work: redis/ioredis#1865 and redis/ioredis#2135.

Closes #29.

## Validation

- `npm run build`
- `npm run lint` (passes with 12 existing warnings)
- `TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test npx mocha "test/helpers/*.ts" test/unit/clusters/ConnectionPool.ts test/functional/cluster/moved.ts` — 13 passing
- full unit run: 71 passing; 2 environment-dependent IPv6 localhost assertions fail because this host resolves `localhost` to IPv4

Live ElastiCache Serverless validation was not available; the regression tests simulate the connection reset/read-only fallback and stale proxy socket behavior.
