### PR TITLE
fix(cluster): retry reads while replicas are loading

### DIFF
--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -174,6 +174,13 @@ class Pipeline extends Commander<{ type: "pipeline" }> {
             _this.exec();
           },
           tryagain: exec,
+          loading: () => {
+            if (cluster.options.scaleReads === "master") {
+              matched = false;
+            } else {
+              exec();
+            }
+          },
           clusterDown: exec,
           connectionClosed: exec,
           maxRedirections: () => {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -517,6 +517,20 @@ class Cluster extends Commander {
             tryConnection(false, `${mapped.host}:${mapped.port}`);
           },
           tryagain: partialTry,
+          loading: function () {
+            if (to === "master") {
+              reject.call(command, err);
+              return;
+            }
+            // With `all`, prefer the primary rather than retrying a replica
+            // that is resynchronizing. With `slave`, retry replica selection.
+            if (_this.options.scaleReads === "all") {
+              to = "master";
+              tryConnection();
+            } else {
+              partialTry();
+            }
+          },
           clusterDown: partialTry,
           connectionClosed: partialTry,
           maxRedirections: function (redirectionError) {
@@ -666,6 +680,10 @@ class Cluster extends Commander {
       handlers.ask(errv[1], errv[2]);
     } else if (errv[0] === "TRYAGAIN") {
       this.delayQueue.push("tryagain", handlers.tryagain, {
+        timeout: this.options.retryDelayOnTryAgain,
+      });
+    } else if (errv[0] === "LOADING") {
+      this.delayQueue.push("loading", handlers.loading, {
         timeout: this.options.retryDelayOnTryAgain,
       });
     } else if (

--- a/test/functional/cluster/loading.ts
+++ b/test/functional/cluster/loading.ts
@@ -1,0 +1,111 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { Cluster } from "../../../lib";
+import * as utils from "../../../lib/utils";
+import MockServer from "../../helpers/mock_server";
+
+describe("cluster:LOADING", () => {
+  const slotTable = [[0, 16383, ["127.0.0.1", 30001], ["127.0.0.1", 30002]]];
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("retries a read when a replica is loading", (done) => {
+    let replicaReads = 0;
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      return "master";
+    });
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get") {
+        if (replicaReads++ === 0) {
+          return new Error("LOADING Redis is loading the dataset in memory");
+        }
+        return "replica";
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      scaleReads: "slave",
+      retryDelayOnTryAgain: 1,
+    });
+    cluster.get("foo", (err, result) => {
+      expect(err).to.eql(null);
+      expect(result).to.eql("replica");
+      expect(replicaReads).to.eql(2);
+      cluster.disconnect();
+      done();
+    });
+  });
+
+  it("falls back to the primary when scaleReads is all", (done) => {
+    let masterReads = 0;
+    let replicaReads = 0;
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get") {
+        masterReads += 1;
+        return "master";
+      }
+    });
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get") {
+        replicaReads += 1;
+        return new Error("LOADING Redis is loading the dataset in memory");
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      scaleReads: "all",
+      retryDelayOnTryAgain: 1,
+    });
+    cluster.on("ready", () => {
+      sinon.stub(utils, "sample").returns("127.0.0.1:30002");
+      cluster.get("foo", (err, result) => {
+        expect(err).to.eql(null);
+        expect(result).to.eql("master");
+        expect(replicaReads).to.eql(1);
+        expect(masterReads).to.eql(1);
+        cluster.disconnect();
+        done();
+      });
+    });
+  });
+
+  it("preserves LOADING errors for primary-only reads", (done) => {
+    let reads = 0;
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return [[0, 16383, ["127.0.0.1", 30001]]];
+      }
+      if (argv[0] === "get") {
+        reads += 1;
+        return new Error("LOADING Redis is loading the dataset in memory");
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      retryDelayOnTryAgain: 1,
+    });
+    cluster.get("foo", (err) => {
+      expect(err).to.have.property(
+        "message",
+        "LOADING Redis is loading the dataset in memory"
+      );
+      expect(reads).to.eql(1);
+      cluster.disconnect();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- recognize `LOADING` as a bounded cluster retry condition
- retry another replica for `scaleReads: "slave"`
- fall back to the primary for `scaleReads: "all"`
- preserve the server error for primary-only reads
- handle retriable pipeline responses consistently

Closes #50.

## Validation

- `npm run build`
- targeted `LOADING` and pipeline tests: 4 passing
- `npm run lint` (existing warnings only)
- `git diff --check`
