### PR TITLE
fix: export Valkey constructor

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ exports = module.exports = require("./Redis").default;
 
 export { default } from "./Redis";
 export { default as Redis } from "./Redis";
+export { default as Valkey } from "./Redis";
 export { default as Cluster } from "./cluster";
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "built/"
   ],
   "scripts": {
-    "test:tsd": "npm run build && tsd",
+    "test:tsd": "npm run build && node test/exports/commonjs.js && node test/exports/esm.mjs && tsd",
     "test:js": "TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha \"test/helpers/*.ts\" \"test/unit/**/*.ts\" \"test/functional/**/*.ts\"",
     "test:cov": "nyc npm run test:js",
     "test:js:cluster": "TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha \"test/cluster/**/*.ts\"",

--- a/test/exports/commonjs.js
+++ b/test/exports/commonjs.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const assert = require("assert");
+const Valkey = require("../../built");
+
+assert.strictEqual(Valkey.Valkey, Valkey);
+assert.strictEqual(Valkey.default, Valkey);
+assert.strictEqual(Valkey.Redis, Valkey);

--- a/test/exports/esm.mjs
+++ b/test/exports/esm.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert";
+import Valkey, {
+  default as ValkeyDefault,
+  Redis,
+  Valkey as NamedValkey,
+} from "../../built/index.js";
+
+assert.strictEqual(NamedValkey, Valkey);
+assert.strictEqual(ValkeyDefault, Valkey);
+assert.strictEqual(Redis, Valkey);

--- a/test/functional/exports.ts
+++ b/test/functional/exports.ts
@@ -1,7 +1,21 @@
-import { Command, Cluster, ReplyError } from "../../lib";
+import ValkeyDefault, {
+  Command,
+  Cluster,
+  Redis,
+  ReplyError,
+  Valkey,
+} from "../../lib";
 import { expect } from "chai";
 
 describe("exports", () => {
+  describe(".Valkey", () => {
+    it("should alias the default and Redis exports", () => {
+      expect(Valkey).to.equal(ValkeyDefault);
+      expect(Valkey).to.equal(Redis);
+      expect(Valkey).to.equal(require("../../lib"));
+    });
+  });
+
   describe(".Command", () => {
     it("should be `Command`", () => {
       expect(Command).to.eql(require("../../lib/Command").default);

--- a/test/typing/options.test-d.ts
+++ b/test/typing/options.test-d.ts
@@ -1,7 +1,15 @@
 import { expectAssignable, expectType } from "tsd";
-import { Redis, Cluster, NatMap, DNSLookupFunction } from "../../built";
+import ValkeyDefault, {
+  Redis,
+  Valkey,
+  Cluster,
+  NatMap,
+  DNSLookupFunction,
+} from "../../built";
 
 expectType<Redis>(new Redis());
+expectType<Redis>(new Valkey());
+expectType<Redis>(new ValkeyDefault());
 
 // TCP
 expectType<Redis>(new Redis());


### PR DESCRIPTION
## Summary

- add the documented `Valkey` named export while preserving the default and `Redis` exports
- verify CommonJS, native ESM, and TypeScript import compatibility
- include export checks in the type-test workflow

This consolidates the minimal API fix discussed across #41, #43, and #44 without their unrelated changes.

Closes #27.

## Validation

- build
- CommonJS and native ESM export fixtures
- tsd
- targeted Mocha tests
- lint and formatting
