### PR TITLE
fix: make familyFallback opt-in as documented

### DIFF
--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -370,7 +370,9 @@ export function validateFamilyFallbackOptions(self: Redis) {
     options?._initialFamily ?? (self.options.family as 4 | 6);
 
   const fallback: FamilyFallback = {
-    enabled: true,
+    // `familyFallback` is opt-in (documented `@default undefined`). Without it,
+    // a plain client would have its `family` switched on every reconnect.
+    enabled: options !== undefined,
     alternate: false,
     _initialFamily: initialFamily,
     _triedFamilyFour: false,

--- a/test/unit/redis.ts
+++ b/test/unit/redis.ts
@@ -258,6 +258,17 @@ describe("Redis", () => {
           done,
         });
       });
+
+      it("should not change family when familyFallback is not specified", (done) => {
+        // familyFallback is opt-in, so a client that never sets it must keep
+        // the family it was configured with across reconnects.
+        testFamilyFallback({
+          redisOptions: {},
+          expectedFamilySequence: [defaultFamily, defaultFamily, defaultFamily],
+          retryLimit: 3,
+          done,
+        });
+      });
     });
 
     describe("family fallback with alternate: false", () => {


### PR DESCRIPTION
### Problem

`familyFallback` is documented as `@default undefined` (i.e. opt-in), and every existing test opts in explicitly. But `validateFamilyFallbackOptions()` builds the fallback config with `enabled: true` whenever the option is absent:

```ts
const fallback: FamilyFallback = {
  enabled: true,   // <- even when the user passed nothing
  alternate: false,
  ...options,
};
```

Since `handleFamilyFallbackOptions()` runs on every reconnect, a plain `new Redis()` (family 4) has its `options.family` silently flipped to 6 after the first disconnect. Against an IPv4-only server this burns a reconnect attempt on an address family the server doesn't accept.

Reproduced with a default client (no `familyFallback` passed) against a local Valkey:

```
[ready #1] options.family = 4 | familyFallback = {"enabled":true,...}
-> forcing a reconnect...
[ready #2] options.family = 6      <-- never opted in
```

### Fix

Default `enabled` to whether the user actually passed `familyFallback`, so the feature stays opt-in as documented. Passing the option — or `{ enabled: false }` — behaves exactly as before.

### Tests

Added a regression test asserting the family is unchanged across reconnects when `familyFallback` is not specified. It fails without this change (`expected 6 to equal 4`) and passes with it. All existing `familyFallback` tests still pass.

Note: the unrelated failure in `test/unit/connectors/connector.ts` (sinon `Attempted to wrap createConnection which is already wrapped`) pre-exists on `main`.
