### PR TITLE
feat(cluster): route sharded Pub/Sub by slot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,22 @@ jobs:
       - name: Build and test cluster
         run: bash test/cluster/docker/main.sh
 
+  test-valkey-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - run: npm ci
+      - name: Test sharded Pub/Sub against Valkey Cluster
+        run: npm run test:integration:valkey-cluster
+
   test-valkey:
     runs-on: ubuntu-latest
     strategy:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,137 @@
+# Sharded Pub/Sub routing
+
+Status: initial contributor design
+
+Issue: [#13](https://github.com/valkey-io/iovalkey/issues/13)
+
+## Problem
+
+Valkey Cluster routes a sharded Pub/Sub channel by its hash slot. `SPUBLISH`, `SSUBSCRIBE`, and `SUNSUBSCRIBE` for a channel must reach the primary that owns that slot.
+
+The cluster client currently uses one randomly selected `ClusterSubscriber` for every subscription command. This works for `SUBSCRIBE` and `PSUBSCRIBE` because classic Pub/Sub messages are propagated across the cluster. It does not work for sharded Pub/Sub: an `SSUBSCRIBE` sent to one shard cannot receive an `SPUBLISH` routed to another shard.
+
+The existing functional test hides the defect by injecting an `smessage` directly into the selected subscriber connection instead of publishing through the cluster.
+
+## Goals
+
+- Route `SSUBSCRIBE` and `SUNSUBSCRIBE` by channel slot ownership.
+- Keep classic `SUBSCRIBE`, `PSUBSCRIBE`, and their message events unchanged.
+- Preserve sharded subscriptions across slot refreshes, failover, and reconnects.
+- Forward `smessage` and `smessageBuffer` through the `Cluster` instance.
+- Open sharded subscriber connections lazily and close all of them on disconnect.
+- Add an end-to-end regression test that uses `SPUBLISH` against an actual Valkey Cluster rather than injecting a message.
+- Make the same containerized integration test runnable locally and in a dedicated GitHub Actions job.
+
+## Non-goals
+
+- Delivery guarantees beyond those provided by Valkey Pub/Sub.
+- Pattern subscriptions for sharded Pub/Sub; Valkey does not provide them.
+- Changes to normal command, pipeline, or `SPUBLISH` routing. `SPUBLISH` already follows the command's key slot through the regular cluster path.
+
+## Proposed design
+
+Keep the existing `ClusterSubscriber` exclusively for classic Pub/Sub. Add two internal components for sharded Pub/Sub:
+
+- `ClusterSubscriberGroup` owns the channel-to-slot registry and coordinates subscribers as cluster topology changes.
+- `ShardedSubscriber` owns one dedicated `Redis` connection to one primary and forwards sharded message events.
+
+The group maintains:
+
+```text
+channelsBySlot: slot -> subscribed channels
+subscribersByNode: primary node key -> ShardedSubscriber
+slots: slot -> current primary node key
+```
+
+There is at most one sharded subscriber per primary with active channels. Connections use `lazyConnect`, have offline queueing enabled, and do not independently reconnect. The group owns reconnection so that a stale connection cannot continue subscribing to a node that no longer owns the slot.
+
+The feature should activate automatically on the first sharded subscription. A new public option is unnecessary when no sharded connections are opened until they are used.
+
+## Command routing
+
+Handle sharded subscription commands before the generic subscriber-mode branch in `Cluster#sendCommand`:
+
+1. Calculate the slot from the first channel.
+2. Reject an explicit multi-channel command if its channels do not share a slot.
+3. Resolve the primary from the current slot cache.
+4. Get or create that primary's `ShardedSubscriber`.
+5. Send the command through its dedicated connection.
+6. Update `channelsBySlot` only when the command succeeds.
+
+`SUNSUBSCRIBE` without channels must be fanned out to every active sharded subscriber and clear the registry. Its callback/promise should resolve once all underlying commands settle, returning the client-wide remaining subscription count.
+
+If no owner is available, reject with a cluster error rather than falling back to a random subscriber.
+
+## Topology and connection lifecycle
+
+After every successful slots-cache refresh, the group compares each subscribed slot's previous and current owner:
+
+- unchanged owners retain their subscriber and subscriptions;
+- changed owners get a subscriber connection and are re-subscribed to the slot's channels;
+- subscribers with no remaining channels are stopped and removed.
+
+A `MOVED` reply or an unexpected sharded-subscriber disconnect triggers a slots refresh using the cluster's existing refresh deduplication and retry policy. After refresh, the group rebuilds only the affected subscribers. Concurrent refreshes must not create duplicate connections or duplicate resubscription work.
+
+`Cluster#disconnect()` and `Cluster#quit()` stop both the classic subscriber and every sharded subscriber. A later `connect()` rebuilds sharded subscribers from the retained channel registry, matching existing resubscription behavior.
+
+## Expected code changes
+
+- Add `lib/cluster/ClusterSubscriberGroup.ts`.
+- Add `lib/cluster/ShardedSubscriber.ts`.
+- Integrate the group into `lib/cluster/index.ts` command routing, slot refresh, connect, and disconnect paths.
+- Keep `lib/cluster/ClusterSubscriber.ts` focused on classic Pub/Sub.
+- Replace the misleading mock assertion in `test/functional/cluster/spub_ssub.ts` and add fast routing, recovery, and cleanup coverage.
+- Add actual-cluster tests under `test/cluster/` and a local Docker launcher under `test/cluster/docker-valkey/`.
+- Add `test:js:valkey-cluster` and `test:integration:valkey-cluster` package scripts.
+- Add a dedicated `test-valkey-cluster` job to `.github/workflows/test.yml`.
+
+The implementation adapts the subscriber-group architecture from ioredis PRs [#1956](https://github.com/redis/ioredis/pull/1956), [#2013](https://github.com/redis/ioredis/pull/2013), [#2043](https://github.com/redis/ioredis/pull/2043), [#2060](https://github.com/redis/ioredis/pull/2060), and [#2090](https://github.com/redis/ioredis/pull/2090). The original work was authored by David Maier and Tihomir Krasimirov Mateev, then evolved by Pavel Pashov and Hristo Temelski. It is adapted rather than cherry-picked wholesale because iovalkey's connection-pool and recovery code has diverged. The implementation commit must retain their `Co-authored-by` trailers.
+
+## Test plan
+
+### Fast tests
+
+1. Use two mock primaries with different slot ranges and verify `SSUBSCRIBE` is sent to the channel's owner.
+2. Verify channels in the same slot share a subscriber and channels on different primaries use different subscribers.
+3. Verify a multi-channel cross-slot `SSUBSCRIBE` is rejected before changing internal state.
+4. Change the mocked slot owner and verify resubscription on the new primary.
+5. Disconnect a sharded subscriber and verify bounded recovery without affecting classic subscriptions.
+6. Verify no sharded connection is opened before `SSUBSCRIBE`.
+7. Verify `SUNSUBSCRIBE` with and without channel arguments updates all relevant subscribers.
+8. Verify `disconnect()` leaves no sharded subscriber connections or listeners.
+
+### Actual Valkey Cluster integration
+
+The Docker test must run six `valkey-server` processes: three primaries and three replicas. Use an explicitly pinned `valkey/valkey` image rather than Redis or `latest`. Running all processes in one container allows the nodes and a host-side test process to use the same announced `127.0.0.1:30000-30005` addresses on Linux, macOS, and CI.
+
+`test/cluster/docker-valkey/main.sh` should:
+
+1. start the container with ports `30000-30005` published;
+2. enable cluster mode for all six processes;
+3. create the cluster with `valkey-cli --cluster create` and one replica per primary;
+4. use a readiness loop based on `CLUSTER INFO`, not a fixed sleep;
+5. run `npm run test:js:valkey-cluster`;
+6. stop the container through an `EXIT` trap, including on test failure.
+
+The integration suite must use two independent `Cluster` clients and exercise the public API only. It must:
+
+- choose channels owned by at least two different primaries;
+- `SSUBSCRIBE` to both channels;
+- call `SPUBLISH` from the second client;
+- assert receipt of the correct `smessage` values with a bounded timeout;
+- unsubscribe and disconnect cleanly so the test cannot pass with leaked handles.
+
+A follow-up integration case should move or fail over one subscribed slot and verify delivery after the slot cache refresh. This recovery case may land separately if the initial PR clearly tracks it.
+
+### GitHub Actions
+
+Add a separate `test-valkey-cluster` job rather than extending the existing Redis-based `test-cluster` job. The job should check out the repository, install the supported Node.js version, run `npm ci`, and invoke `npm run test:integration:valkey-cluster`. Docker logs and `CLUSTER NODES` output should be printed on failure. Keeping this as a distinct required check makes it clear that sharded Pub/Sub was tested against Valkey itself.
+
+## Initial acceptance criteria
+
+- The reproduction in issue #13 receives `smessage` reliably when publisher and subscriber are separate `Cluster` instances.
+- Sharded subscription commands never use an unrelated random node.
+- Classic Pub/Sub tests remain unchanged and passing.
+- The dedicated `test-valkey-cluster` GitHub Actions job passes against the pinned Valkey image.
+- The same integration test runs locally through one documented npm command.
+- Slot migration and reconnect tests pass without leaked connections or unhandled errors.

--- a/lib/cluster/ClusterSubscriberGroup.ts
+++ b/lib/cluster/ClusterSubscriberGroup.ts
@@ -1,0 +1,658 @@
+import { Debug } from "../utils";
+import { getNodeKey, RedisOptions } from "./util";
+import * as calculateSlot from "cluster-key-slot";
+import * as EventEmitter from "events";
+import ShardedSubscriber from "./ShardedSubscriber";
+import { ClusterOptions } from "./ClusterOptions";
+const debug = Debug("cluster:subscriberGroup");
+
+/**
+ * Redis distinguishes between "normal" and sharded PubSub. When using the normal PubSub feature,
+ * exactly one subscriber exists per cluster instance because the Redis cluster bus forwards
+ * messages between shards. Sharded PubSub removes this limitation by making each shard
+ * responsible for its own messages.
+ *
+ * This class coordinates one ShardedSubscriber per master node in the cluster, providing
+ * sharded PubSub support while keeping the public API backward compatible.
+ */
+export default class ClusterSubscriberGroup {
+  private static readonly MAX_RETRY_ATTEMPTS = 10;
+  private static readonly MAX_BACKOFF_MS = 2000;
+  private static readonly BASE_BACKOFF_MS = 100;
+
+  private shardedSubscribers: Map<string, ShardedSubscriber> = new Map();
+  private clusterSlots: string[][] = [];
+  // Simple [min, max] slot ranges aren't enough because you can migrate single slots
+  private subscriberToSlotsIndex: Map<string, number[]> = new Map();
+  private channels: Map<number, Map<string, string | Buffer>> = new Map();
+  private failedAttemptsByNode: Map<string, number> = new Map();
+  private nodeOptionsByKey: Map<string, RedisOptions> = new Map();
+  private staleOwnersBySlot: Map<number, Set<string>> = new Map();
+  private staleChannelsByNode: Map<string, Map<string, string | Buffer>> =
+    new Map();
+
+  // Only latest pending reset kept; throttled by refreshSlotsCache's isRefreshing + backoff delay
+  private isResetting = false;
+  private pendingReset: { slots: string[][]; nodes: any[] } | null = null;
+  private lifecycleEpoch = 0;
+
+  /**
+   * Register callbacks
+   *
+   * @param cluster
+   */
+  constructor(
+    private readonly subscriberGroupEmitter: EventEmitter,
+    private readonly options: ClusterOptions
+  ) {}
+
+  /**
+   * Get the responsible subscriber.
+   *
+   * @param slot
+   */
+  getResponsibleSubscriber(slot: number): ShardedSubscriber | undefined {
+    const nodeKey = this.clusterSlots[slot]?.[0];
+    if (!nodeKey) {
+      return undefined;
+    }
+
+    const sub = this.getOrCreateSubscriber(nodeKey);
+    if (sub && sub.subscriberStatus === "idle") {
+      sub
+        .start()
+        .then(() => {
+          this.handleSubscriberConnectSucceeded(sub.getNodeKey());
+        })
+        .catch((err) => {
+          this.handleSubscriberConnectFailed(err, sub.getNodeKey());
+        });
+    }
+
+    return sub;
+  }
+
+  updateSlotOwner(slot: number, nodeKey: string, options: RedisOptions): void {
+    const previousNodeKey = this.clusterSlots[slot]?.[0];
+    this.clusterSlots[slot] = [nodeKey];
+    this.nodeOptionsByKey.set(nodeKey, options);
+
+    if (previousNodeKey && previousNodeKey !== nodeKey) {
+      const staleOwners = this.staleOwnersBySlot.get(slot) || new Set();
+      staleOwners.add(previousNodeKey);
+      this.staleOwnersBySlot.set(slot, staleOwners);
+
+      const staleChannels =
+        this.staleChannelsByNode.get(previousNodeKey) || new Map();
+      for (const [key, channel] of this.channels.get(slot) || []) {
+        staleChannels.set(key, channel);
+      }
+      this.staleChannelsByNode.set(previousNodeKey, staleChannels);
+
+      const previousSlots = this.subscriberToSlotsIndex.get(previousNodeKey);
+      if (previousSlots) {
+        this.subscriberToSlotsIndex.set(
+          previousNodeKey,
+          previousSlots.filter((candidate) => candidate !== slot)
+        );
+      }
+    }
+    const targetSlots = this.subscriberToSlotsIndex.get(nodeKey) || [];
+    if (!targetSlots.includes(slot)) {
+      targetSlots.push(slot);
+      this.subscriberToSlotsIndex.set(nodeKey, targetSlots);
+    }
+  }
+
+  validateChannels(channels: (string | Buffer)[]): boolean {
+    if (channels.length === 0) {
+      return false;
+    }
+    const slot = calculateSlot(channels[0]);
+    return channels.every((channel) => calculateSlot(channel) === slot);
+  }
+
+  /**
+   * Adds a channel for which this subscriber group is responsible
+   *
+   * @param channels
+   */
+  addChannels(channels: (string | Buffer)[]): number {
+    if (!this.validateChannels(channels)) {
+      return -1;
+    }
+
+    const slot = calculateSlot(channels[0]);
+    let slotChannels = this.channels.get(slot);
+    if (!slotChannels) {
+      slotChannels = new Map();
+      this.channels.set(slot, slotChannels);
+    }
+    for (const channel of channels) {
+      slotChannels.set(this.channelKey(channel), channel);
+    }
+
+    return this.channelCount();
+  }
+
+  /**
+   * Removes channels for which the subscriber group is responsible by optionally unsubscribing
+   * @param channels
+   */
+  removeChannels(channels: (string | Buffer)[]): number {
+    if (!this.validateChannels(channels)) {
+      return -1;
+    }
+
+    const slot = calculateSlot(channels[0]);
+    const slotChannels = this.channels.get(slot);
+    if (slotChannels) {
+      for (const channel of channels) {
+        slotChannels.delete(this.channelKey(channel));
+      }
+      if (slotChannels.size === 0) {
+        this.channels.delete(slot);
+      }
+    }
+
+    this.pruneSubscribers();
+    return this.channelCount();
+  }
+
+  async unsubscribeAll(): Promise<number> {
+    const pending: Promise<unknown>[] = [];
+    for (const subscriber of this.shardedSubscribers.values()) {
+      const redis = subscriber.getInstance();
+      if (redis && subscriber.isStarted()) {
+        pending.push(redis.sunsubscribe());
+      }
+    }
+
+    await Promise.all(pending);
+    this.channels.clear();
+    this.pruneSubscribers();
+    return 0;
+  }
+
+  /**
+   * Disconnect all subscribers and clear some of the internal state.
+   */
+  stop() {
+    for (const s of this.shardedSubscribers.values()) {
+      s.stop();
+    }
+
+    // Clear subscriber instances and pending operations.
+    // Channels are preserved for resubscription on reconnect.
+    this.lifecycleEpoch += 1;
+    this.pendingReset = null;
+    this.shardedSubscribers.clear();
+    this.subscriberToSlotsIndex.clear();
+    this.nodeOptionsByKey.clear();
+    this.failedAttemptsByNode.clear();
+    this.staleOwnersBySlot.clear();
+    this.staleChannelsByNode.clear();
+  }
+
+  /**
+   * Start all not yet started subscribers
+   */
+  start() {
+    const startPromises = [];
+    for (const s of this.shardedSubscribers.values()) {
+      if (this.shouldStartSubscriber(s)) {
+        startPromises.push(
+          s
+            .start()
+            .then(() => {
+              this.handleSubscriberConnectSucceeded(s.getNodeKey());
+            })
+            .catch((err) => {
+              this.handleSubscriberConnectFailed(err, s.getNodeKey());
+            })
+        );
+
+        this.subscriberGroupEmitter.emit("+subscriber");
+      }
+    }
+    return Promise.all(startPromises);
+  }
+
+  /**
+   * Resets the subscriber group by disconnecting all subscribers that are no longer needed and connecting new ones.
+   */
+  async reset(clusterSlots: string[][], clusterNodes: any[]): Promise<void> {
+    if (this.isResetting) {
+      this.pendingReset = { slots: clusterSlots, nodes: clusterNodes };
+      return;
+    }
+
+    this.isResetting = true;
+    const lifecycleEpoch = this.lifecycleEpoch;
+
+    try {
+      this.nodeOptionsByKey = new Map(
+        clusterNodes.map((node) => [getNodeKey(node.options), node.options])
+      );
+      const previousSlots = this.clusterSlots.map((nodes) => nodes?.slice());
+      const staleOwnersBySlot = this.staleOwnersBySlot;
+      const staleChannelsByNode = this.staleChannelsByNode;
+      this.staleOwnersBySlot = new Map();
+      this.staleChannelsByNode = new Map();
+      const hasTopologyChanged = this._refreshSlots(clusterSlots);
+      const hasFailedSubscribers = this.hasUnhealthySubscribers();
+
+      if (
+        !hasTopologyChanged &&
+        !hasFailedSubscribers &&
+        staleOwnersBySlot.size === 0 &&
+        staleChannelsByNode.size === 0
+      ) {
+        debug(
+          "No topology change detected or failed subscribers. Skipping reset."
+        );
+        return;
+      }
+
+      if (hasTopologyChanged || staleOwnersBySlot.size > 0) {
+        await this.unsubscribeMovedChannels(
+          previousSlots,
+          staleOwnersBySlot,
+          staleChannelsByNode
+        );
+      }
+      if (lifecycleEpoch !== this.lifecycleEpoch) {
+        return;
+      }
+
+      // For each of the sharded subscribers
+      for (const [nodeKey, shardedSubscriber] of this.shardedSubscribers) {
+        if (
+          // If the subscriber is still responsible for a slot range and is healthy then keep it
+          this.subscriberToSlotsIndex.has(nodeKey) &&
+          this.nodeHasChannels(nodeKey) &&
+          shardedSubscriber.isHealthy()
+        ) {
+          debug("Skipping deleting subscriber for %s", nodeKey);
+          continue;
+        }
+
+        debug("Removing subscriber for %s", nodeKey);
+        // Otherwise stop the subscriber and remove it
+        shardedSubscriber.stop();
+        this.shardedSubscribers.delete(nodeKey);
+
+        this.subscriberGroupEmitter.emit("-subscriber");
+      }
+
+      const startPromises = [];
+      // For each node in slots cache
+      for (const nodeKey of this.subscriberToSlotsIndex.keys()) {
+        if (!this.nodeHasChannels(nodeKey)) {
+          continue;
+        }
+        const existingSubscriber = this.shardedSubscribers.get(nodeKey);
+
+        // If we already have a subscriber for this node, only ensure it is healthy
+        // when it now owns slots with active channel subscriptions.
+        if (existingSubscriber && existingSubscriber.isHealthy()) {
+          debug("Skipping creating new subscriber for %s", nodeKey);
+
+          if (
+            !existingSubscriber.isStarted() &&
+            this.shouldStartSubscriber(existingSubscriber)
+          ) {
+            startPromises.push(
+              existingSubscriber
+                .start()
+                .then(() => {
+                  this.handleSubscriberConnectSucceeded(nodeKey);
+                })
+                .catch((error) => {
+                  this.handleSubscriberConnectFailed(error, nodeKey);
+                })
+            );
+          }
+
+          continue;
+        }
+
+        // If we have an existing subscriber but it is not healthy, stop it
+        if (existingSubscriber && !existingSubscriber.isHealthy()) {
+          debug("Replacing subscriber for %s", nodeKey);
+          existingSubscriber.stop();
+          this.shardedSubscribers.delete(nodeKey);
+          this.subscriberGroupEmitter.emit("-subscriber");
+        }
+
+        debug("Creating new subscriber for %s", nodeKey);
+        const sub = this.getOrCreateSubscriber(nodeKey);
+        if (!sub) {
+          debug("Failed to find node options for key %s", nodeKey);
+          continue;
+        }
+
+        if (this.shouldStartSubscriber(sub)) {
+          startPromises.push(
+            sub
+              .start()
+              .then(() => {
+                this.handleSubscriberConnectSucceeded(nodeKey);
+              })
+              .catch((error) => {
+                this.handleSubscriberConnectFailed(error, nodeKey);
+              })
+          );
+        }
+      }
+
+      // It's vital to await the start promises before resubscribing
+      // Otherwise we might try to resubscribe to a subscriber that is not yet connected
+      // This can cause a race condition
+      await Promise.all(startPromises);
+      if (lifecycleEpoch !== this.lifecycleEpoch) {
+        return;
+      }
+
+      this._resubscribe();
+      this.subscriberGroupEmitter.emit("subscribersReady");
+    } finally {
+      this.isResetting = false;
+      if (this.pendingReset) {
+        const { slots, nodes } = this.pendingReset;
+        this.pendingReset = null;
+        await this.reset(slots, nodes);
+      }
+    }
+  }
+
+  /**
+   * Refreshes the subscriber-related slot ranges
+   *
+   * Returns false if no refresh was needed
+   *
+   * @param targetSlots
+   */
+  private _refreshSlots(targetSlots: string[][]): boolean {
+    //If there was an actual change, then reassign the slot ranges
+    // Also rebuild if subscriberToSlotsIndex is empty (e.g., after stop() was called)
+    if (
+      this._slotsAreEqual(targetSlots) &&
+      this.subscriberToSlotsIndex.size > 0
+    ) {
+      debug(
+        "Nothing to refresh because the new cluster map is equal to the previous one."
+      );
+
+      return false;
+    }
+
+    debug("Refreshing the slots of the subscriber group.");
+
+    //Rebuild the slots index
+    this.subscriberToSlotsIndex = new Map();
+
+    for (let slot = 0; slot < targetSlots.length; slot++) {
+      const node: string = targetSlots[slot][0];
+
+      if (!this.subscriberToSlotsIndex.has(node)) {
+        this.subscriberToSlotsIndex.set(node, []);
+      }
+      this.subscriberToSlotsIndex.get(node).push(Number(slot));
+    }
+
+    //Update the cached slots map
+    this.clusterSlots = JSON.parse(JSON.stringify(targetSlots));
+
+    return true;
+  }
+
+  /**
+   * Resubscribes to the previous channels
+   *
+   * @private
+   */
+  private _resubscribe() {
+    if (this.shardedSubscribers) {
+      this.shardedSubscribers.forEach(
+        (s: ShardedSubscriber, nodeKey: string) => {
+          const subscriberSlots = this.subscriberToSlotsIndex.get(nodeKey);
+          if (subscriberSlots) {
+            //Resubscribe on the underlying connection
+            subscriberSlots.forEach((ss) => {
+              //Might return null if being disconnected
+              const redis = s.getInstance();
+              const slotChannels = this.channels.get(ss);
+              const channels = slotChannels
+                ? Array.from(slotChannels.values())
+                : [];
+
+              if (channels.length > 0) {
+                if (!redis || redis.status === "end") {
+                  return;
+                }
+
+                if (redis.status === "ready") {
+                  redis.ssubscribe(...channels).catch((err) => {
+                    debug("Failed to ssubscribe on node %s: %s", nodeKey, err);
+                    this.handleSubscriberConnectFailed(err, nodeKey);
+                  });
+                } else {
+                  redis.once("ready", () => {
+                    redis.ssubscribe(...channels).catch((err) => {
+                      debug(
+                        "Failed to ssubscribe on node %s: %s",
+                        nodeKey,
+                        err
+                      );
+                      this.handleSubscriberConnectFailed(err, nodeKey);
+                    });
+                  });
+                }
+              }
+            });
+          }
+        }
+      );
+    }
+  }
+
+  /**
+   * Deep equality of the cluster slots objects
+   *
+   * @param other
+   * @private
+   */
+  private _slotsAreEqual(other: string[][]) {
+    if (this.clusterSlots === undefined) {
+      return false;
+    } else {
+      return JSON.stringify(this.clusterSlots) === JSON.stringify(other);
+    }
+  }
+
+  /**
+   * Checks if any subscribers are in an unhealthy state.
+   *
+   * A subscriber is considered unhealthy if:
+   * - It exists but is not started (failed/disconnected)
+   * - It's missing entirely for a node that should have one
+   *
+   * @returns true if any subscribers need to be recreated
+   */
+  private hasUnhealthySubscribers(): boolean {
+    const hasFailedSubscribers = Array.from(
+      this.shardedSubscribers.values()
+    ).some((sub) => !sub.isHealthy());
+
+    const hasMissingSubscribers = Array.from(
+      this.subscriberToSlotsIndex.keys()
+    ).some((nodeKey) => !this.shardedSubscribers.has(nodeKey));
+
+    return hasFailedSubscribers || hasMissingSubscribers;
+  }
+
+  /**
+   * Handles failed subscriber connections by emitting an event to refresh the slots cache
+   * after a backoff period.
+   *
+   * @param error
+   * @param nodeKey
+   */
+  private handleSubscriberConnectFailed = (error: Error, nodeKey: string) => {
+    const currentAttempts = this.failedAttemptsByNode.get(nodeKey) || 0;
+    const failedAttempts = currentAttempts + 1;
+    this.failedAttemptsByNode.set(nodeKey, failedAttempts);
+
+    const attempts = Math.min(
+      failedAttempts,
+      ClusterSubscriberGroup.MAX_RETRY_ATTEMPTS
+    );
+    const backoff = Math.min(
+      ClusterSubscriberGroup.BASE_BACKOFF_MS * 2 ** attempts,
+      ClusterSubscriberGroup.MAX_BACKOFF_MS
+    );
+    const jitter = Math.floor((Math.random() - 0.5) * (backoff * 0.5));
+    const delay = Math.max(0, backoff + jitter);
+
+    debug(
+      "Failed to connect subscriber for %s. Refreshing slots in %dms",
+      nodeKey,
+      delay
+    );
+
+    this.subscriberGroupEmitter.emit("subscriberConnectFailed", {
+      delay,
+      error,
+    });
+  };
+
+  /**
+   * Handles successful subscriber connections by resetting the failed attempts counter.
+   *
+   * @param nodeKey
+   */
+  private handleSubscriberConnectSucceeded = (nodeKey: string) => {
+    this.failedAttemptsByNode.delete(nodeKey);
+  };
+
+  private shouldStartSubscriber(sub: ShardedSubscriber): boolean {
+    if (sub.isStarted()) {
+      return false;
+    }
+
+    if (!sub.isLazyConnect()) {
+      return true;
+    }
+
+    const subscriberSlots = this.subscriberToSlotsIndex.get(sub.getNodeKey());
+
+    if (!subscriberSlots) {
+      return false;
+    }
+
+    return subscriberSlots.some((slot) => {
+      const channels = this.channels.get(slot);
+      return Boolean(channels && channels.size > 0);
+    });
+  }
+
+  private getOrCreateSubscriber(
+    nodeKey: string
+  ): ShardedSubscriber | undefined {
+    const existing = this.shardedSubscribers.get(nodeKey);
+    if (existing) {
+      return existing;
+    }
+
+    const options = this.nodeOptionsByKey.get(nodeKey);
+    if (!options) {
+      return undefined;
+    }
+
+    const subscriber = new ShardedSubscriber(
+      this.subscriberGroupEmitter,
+      options,
+      this.options.redisOptions
+    );
+    this.shardedSubscribers.set(nodeKey, subscriber);
+    this.subscriberGroupEmitter.emit("+subscriber");
+    return subscriber;
+  }
+
+  private nodeHasChannels(nodeKey: string): boolean {
+    const slots = this.subscriberToSlotsIndex.get(nodeKey) || [];
+    return slots.some((slot) => Boolean(this.channels.get(slot)?.size));
+  }
+
+  private pruneSubscribers(): void {
+    for (const [nodeKey, subscriber] of this.shardedSubscribers) {
+      if (!this.nodeHasChannels(nodeKey)) {
+        subscriber.stop();
+        this.shardedSubscribers.delete(nodeKey);
+        this.subscriberGroupEmitter.emit("-subscriber");
+      }
+    }
+  }
+
+  private async unsubscribeMovedChannels(
+    previousSlots: string[][],
+    staleOwnersBySlot: Map<number, Set<string>>,
+    staleChannelsByNode: Map<string, Map<string, string | Buffer>>
+  ): Promise<void> {
+    const channelsByPreviousNode = new Map<string, Array<string | Buffer>>(
+      Array.from(staleChannelsByNode, ([nodeKey, channels]) => [
+        nodeKey,
+        Array.from(channels.values()),
+      ])
+    );
+    for (const [slot, slotChannels] of this.channels) {
+      const currentNodeKey = this.clusterSlots[slot]?.[0];
+      const previousNodeKeys = new Set<string>(
+        staleOwnersBySlot.get(slot) || []
+      );
+      const previousNodeKey = previousSlots[slot]?.[0];
+      if (previousNodeKey) {
+        previousNodeKeys.add(previousNodeKey);
+      }
+
+      for (const nodeKey of previousNodeKeys) {
+        if (nodeKey === currentNodeKey) {
+          continue;
+        }
+        const channels = channelsByPreviousNode.get(nodeKey) || [];
+        channels.push(...slotChannels.values());
+        channelsByPreviousNode.set(nodeKey, channels);
+      }
+    }
+
+    await Promise.all(
+      Array.from(channelsByPreviousNode, async ([nodeKey, channels]) => {
+        const subscriber = this.shardedSubscribers.get(nodeKey);
+        const redis = subscriber?.getInstance();
+        if (!subscriber || !redis || !subscriber.isStarted()) {
+          return;
+        }
+        try {
+          await redis.sunsubscribe(...channels);
+        } catch (error) {
+          subscriber.stop();
+          this.shardedSubscribers.delete(nodeKey);
+          this.subscriberGroupEmitter.emit("-subscriber");
+          this.subscriberGroupEmitter.emit("nodeError", error, nodeKey);
+        }
+      })
+    );
+  }
+
+  private channelKey(channel: string | Buffer): string {
+    return Buffer.from(channel).toString("base64");
+  }
+
+  private channelCount(): number {
+    return Array.from(this.channels.values()).reduce(
+      (sum, channels) => sum + channels.size,
+      0
+    );
+  }
+}

--- a/lib/cluster/ShardedSubscriber.ts
+++ b/lib/cluster/ShardedSubscriber.ts
@@ -1,0 +1,203 @@
+import EventEmitter = require("events");
+import { getConnectionName, getNodeKey, RedisOptions } from "./util";
+import { Debug, defaults } from "../utils";
+import Redis from "../Redis";
+import { ClusterOptions } from "./ClusterOptions";
+const debug = Debug("cluster:subscriberGroup:shardedSubscriber");
+
+const SubscriberStatus = {
+  IDLE: "idle",
+  STARTING: "starting",
+  CONNECTED: "connected",
+  STOPPING: "stopping",
+  ENDED: "ended",
+} as const;
+
+type SubscriberStatus = typeof SubscriberStatus[keyof typeof SubscriberStatus];
+
+const ALLOWED_STATUS_UPDATES: Record<SubscriberStatus, SubscriberStatus[]> = {
+  [SubscriberStatus.IDLE]: [
+    SubscriberStatus.STARTING,
+    SubscriberStatus.STOPPING,
+    SubscriberStatus.ENDED,
+  ],
+  [SubscriberStatus.STARTING]: [
+    SubscriberStatus.CONNECTED,
+    SubscriberStatus.STOPPING,
+    SubscriberStatus.ENDED,
+  ],
+  [SubscriberStatus.CONNECTED]: [
+    SubscriberStatus.STOPPING,
+    SubscriberStatus.ENDED,
+  ],
+  [SubscriberStatus.STOPPING]: [SubscriberStatus.ENDED],
+  [SubscriberStatus.ENDED]: [],
+};
+
+export default class ShardedSubscriber {
+  private readonly nodeKey: string;
+  private status: SubscriberStatus = SubscriberStatus.IDLE;
+  private instance: Redis | null = null;
+  private connectPromise: Promise<void> | null = null;
+  private lazyConnect: boolean;
+
+  // Store listener references for cleanup
+  private readonly messageListeners: Map<string, (...args: any[]) => void> =
+    new Map();
+
+  constructor(
+    private readonly emitter: EventEmitter,
+    options: RedisOptions,
+    redisOptions?: ClusterOptions["redisOptions"]
+  ) {
+    this.instance = new Redis(
+      defaults(
+        {
+          enableReadyCheck: false,
+          enableOfflineQueue: true,
+          connectionName: getConnectionName(
+            "ssubscriber",
+            options.connectionName
+          ),
+          /**
+           * Disable auto reconnection for subscribers.
+           * The ClusterSubscriberGroup will handle the reconnection.
+           */
+          retryStrategy: null,
+          lazyConnect: true,
+        },
+        options,
+        redisOptions
+      )
+    );
+
+    this.lazyConnect = redisOptions?.lazyConnect ?? true;
+
+    this.nodeKey = getNodeKey(options);
+
+    // Register listeners
+    this.instance.on("end", this.onEnd);
+    this.instance.on("error", this.onError);
+    this.instance.on("moved", this.onMoved);
+
+    for (const event of ["smessage", "smessageBuffer"]) {
+      const listener = (...args: any[]) => {
+        this.emitter.emit(event, ...args);
+      };
+      this.messageListeners.set(event, listener);
+      this.instance.on(event, listener);
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+
+    if (
+      this.status === SubscriberStatus.STARTING ||
+      this.status === SubscriberStatus.CONNECTED
+    ) {
+      return;
+    }
+
+    if (this.status === SubscriberStatus.ENDED || !this.instance) {
+      throw new Error(
+        `Sharded subscriber ${this.nodeKey} cannot be restarted once ended.`
+      );
+    }
+
+    this.updateStatus(SubscriberStatus.STARTING);
+    this.connectPromise = this.instance.connect();
+
+    try {
+      await this.connectPromise;
+      this.updateStatus(SubscriberStatus.CONNECTED);
+    } catch (err) {
+      this.updateStatus(SubscriberStatus.ENDED);
+      throw err;
+    } finally {
+      this.connectPromise = null;
+    }
+  }
+
+  stop(): void {
+    this.updateStatus(SubscriberStatus.STOPPING);
+
+    if (this.instance) {
+      this.instance.disconnect();
+      this.instance.removeAllListeners();
+      this.messageListeners.clear();
+      this.instance = null;
+    }
+
+    this.updateStatus(SubscriberStatus.ENDED);
+    debug("stopped %s", this.nodeKey);
+  }
+
+  isStarted(): boolean {
+    return (
+      [
+        SubscriberStatus.CONNECTED,
+        SubscriberStatus.STARTING,
+      ] as SubscriberStatus[]
+    ).includes(this.status);
+  }
+
+  get subscriberStatus(): SubscriberStatus {
+    return this.status;
+  }
+
+  isHealthy(): boolean {
+    return (
+      (this.status === SubscriberStatus.IDLE ||
+        this.status === SubscriberStatus.CONNECTED ||
+        this.status === SubscriberStatus.STARTING) &&
+      this.instance !== null
+    );
+  }
+
+  getInstance(): Redis | null {
+    return this.instance;
+  }
+
+  getNodeKey(): string {
+    return this.nodeKey;
+  }
+
+  isLazyConnect(): boolean {
+    return this.lazyConnect;
+  }
+
+  private onEnd = () => {
+    this.updateStatus(SubscriberStatus.ENDED);
+    this.emitter.emit("-node", this.instance, this.nodeKey);
+  };
+
+  private onError = (error: Error) => {
+    this.emitter.emit("nodeError", error, this.nodeKey);
+  };
+
+  private onMoved = () => {
+    this.emitter.emit("moved");
+  };
+
+  private updateStatus(nextStatus: SubscriberStatus): void {
+    if (this.status === nextStatus) {
+      return;
+    }
+
+    if (!ALLOWED_STATUS_UPDATES[this.status].includes(nextStatus)) {
+      debug(
+        "Invalid status transition for %s: %s -> %s",
+        this.nodeKey,
+        this.status,
+        nextStatus
+      );
+
+      return;
+    }
+
+    this.status = nextStatus;
+  }
+}

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -23,6 +23,7 @@ import applyMixin from "../utils/applyMixin";
 import Commander from "../utils/Commander";
 import { ClusterOptions, DEFAULT_CLUSTER_OPTIONS } from "./ClusterOptions";
 import ClusterSubscriber from "./ClusterSubscriber";
+import ClusterSubscriberGroup from "./ClusterSubscriberGroup";
 import ConnectionPool from "./ConnectionPool";
 import DelayQueue from "./DelayQueue";
 import {
@@ -42,6 +43,7 @@ import Deque = require("denque");
 const debug = Debug("cluster");
 
 const REJECT_OVERWRITTEN_COMMANDS = new WeakSet<Command>();
+const SHARDED_STATE_COMMANDS = new WeakSet<Command>();
 
 type OfflineQueueItem = {
   command: Command;
@@ -97,6 +99,9 @@ class Cluster extends Commander {
   private delayQueue: DelayQueue = new DelayQueue();
   private offlineQueue = new Deque<OfflineQueueItem>();
   private subscriber: ClusterSubscriber;
+  private shardedSubscribers: ClusterSubscriberGroup;
+  private subscriberGroupEmitter: EventEmitter;
+  private shardedSubscriberRetryTimers: Set<NodeJS.Timeout> = new Set();
   private slotsTimer: NodeJS.Timer;
   private reconnectTimeout: NodeJS.Timer;
   private isRefreshing = false;
@@ -121,6 +126,7 @@ class Cluster extends Commander {
 
     this.startupNodes = startupNodes;
     this.options = defaults({}, options, DEFAULT_CLUSTER_OPTIONS, this.options);
+    this.createShardedSubscriberGroup();
 
     if (
       this.options.redisOptions &&
@@ -294,8 +300,10 @@ class Cluster extends Commander {
       debug("Canceled reconnecting attempts");
     }
     this.clearNodesRefreshInterval();
+    this.clearShardedSubscriberRetryTimers();
 
     this.subscriber.stop();
+    this.shardedSubscribers.stop();
     if (status === "wait") {
       this.setStatus("close");
       this.handleCloseEvent();
@@ -318,8 +326,10 @@ class Cluster extends Commander {
       this.reconnectTimeout = null;
     }
     this.clearNodesRefreshInterval();
+    this.clearShardedSubscriberRetryTimers();
 
     this.subscriber.stop();
+    this.shardedSubscribers.stop();
 
     if (status === "wait") {
       const ret = asCallback(Promise.resolve<"OK">("OK"), callback);
@@ -502,15 +512,15 @@ class Cluster extends Commander {
           moved: function (slot, key) {
             debug("command %s is moved to %s", command.name, key);
             targetSlot = Number(slot);
+            const mapped = _this.natMapper(key);
+            const mappedKey = getNodeKey(mapped);
             if (_this.slots[slot]) {
-              _this.slots[slot][0] = key;
+              _this.slots[slot][0] = mappedKey;
             } else {
-              _this.slots[slot] = [key];
+              _this.slots[slot] = [mappedKey];
             }
             _this._groupsBySlot[slot] =
               _this._groupsIds[_this.slots[slot].join(";")];
-            const mapped = _this.natMapper(key);
-            const mappedKey = getNodeKey(mapped);
             if (
               lastRedis &&
               getNodeKey(lastRedis.options as RedisOptions) === mappedKey &&
@@ -527,6 +537,11 @@ class Cluster extends Commander {
             } else {
               _this.connectionPool.findOrCreate(mapped);
             }
+            _this.shardedSubscribers.updateSlotOwner(
+              Number(slot),
+              mappedKey,
+              mapped
+            );
             tryConnection();
             debug("refreshing slot caches... (triggered by MOVED error)");
             _this.refreshSlotsCache();
@@ -578,7 +593,62 @@ class Cluster extends Commander {
           Command.checkFlag("ENTER_SUBSCRIBER_MODE", command.name) ||
           Command.checkFlag("EXIT_SUBSCRIBER_MODE", command.name)
         ) {
-          redis = _this.subscriber.getInstance();
+          if (
+            command.name === "ssubscribe" ||
+            command.name === "sunsubscribe"
+          ) {
+            if (typeof targetSlot !== "number") {
+              if (
+                command.name === "sunsubscribe" &&
+                command.args.length === 0
+              ) {
+                _this.shardedSubscribers.unsubscribeAll().then(
+                  (count) => command.resolve(count),
+                  (error) => command.reject(error)
+                );
+              } else {
+                command.reject(
+                  new AbortError("A sharded subscription channel is required")
+                );
+              }
+              return;
+            }
+
+            const channels = command.getKeys();
+            if (!_this.shardedSubscribers.validateChannels(channels)) {
+              command.reject(
+                new AbortError(
+                  "CROSSSLOT Keys in request don't hash to the same slot"
+                )
+              );
+              return;
+            }
+
+            const shardedSubscriber =
+              _this.shardedSubscribers.getResponsibleSubscriber(targetSlot);
+            if (!shardedSubscriber) {
+              command.reject(
+                new AbortError(`No sharded subscriber for slot: ${targetSlot}`)
+              );
+              return;
+            }
+
+            if (!SHARDED_STATE_COMMANDS.has(command)) {
+              SHARDED_STATE_COMMANDS.add(command);
+              const resolve = command.resolve;
+              command.resolve = (count) => {
+                const globalCount =
+                  command.name === "ssubscribe"
+                    ? _this.shardedSubscribers.addChannels(channels)
+                    : _this.shardedSubscribers.removeChannels(channels);
+                resolve(globalCount < 0 ? count : globalCount);
+              };
+            }
+            redis = shardedSubscriber.getInstance();
+          } else {
+            redis = _this.subscriber.getInstance();
+          }
+
           if (!redis) {
             command.reject(new AbortError("No subscriber for the cluster"));
             return;
@@ -742,6 +812,13 @@ class Cluster extends Commander {
     this.offlineQueue = new Deque();
   }
 
+  private clearShardedSubscriberRetryTimers() {
+    for (const timer of this.shardedSubscriberRetryTimers) {
+      clearTimeout(timer);
+    }
+    this.shardedSubscriberRetryTimers.clear();
+  }
+
   private clearNodesRefreshInterval() {
     if (this.slotsTimer) {
       clearTimeout(this.slotsTimer);
@@ -836,9 +913,7 @@ class Cluster extends Commander {
 
   private natMapper(nodeKey: NodeKey | RedisOptions): RedisOptions {
     const key =
-      typeof nodeKey === "string"
-        ? nodeKey
-        : `${nodeKey.host}:${nodeKey.port}`;
+      typeof nodeKey === "string" ? nodeKey : `${nodeKey.host}:${nodeKey.port}`;
 
     let mapped = null;
     if (this.options.natMap && typeof this.options.natMap === "function") {
@@ -954,6 +1029,11 @@ class Cluster extends Commander {
         }
 
         this.connectionPool.reset(nodes);
+        this.shardedSubscribers
+          .reset(this.slots, this.connectionPool.getNodes("all"))
+          .catch((err) => {
+            Redis.prototype.silentEmit.call(this, "error", err);
+          });
         callback();
       }, this.options.slotsRefreshTimeout)
     );
@@ -1093,6 +1173,73 @@ class Cluster extends Commander {
       }
       return Object.assign({}, node, { host: config });
     });
+  }
+
+  private createShardedSubscriberGroup() {
+    this.subscriberGroupEmitter = new EventEmitter();
+    this.shardedSubscribers = new ClusterSubscriberGroup(
+      this.subscriberGroupEmitter,
+      this.options
+    );
+
+    const refreshSlotsCacheCallback = (err?: Error) => {
+      if (err instanceof ClusterAllFailedError) {
+        this.disconnect(true);
+      }
+    };
+
+    this.subscriberGroupEmitter.on("-node", (redis, nodeKey) => {
+      this.emit("-node", redis, nodeKey);
+      this.refreshSlotsCache(refreshSlotsCacheCallback);
+    });
+    this.subscriberGroupEmitter.on(
+      "subscriberConnectFailed",
+      ({ delay, error }) => {
+        if (
+          this.status === "disconnecting" ||
+          this.status === "close" ||
+          this.status === "end"
+        ) {
+          return;
+        }
+
+        Redis.prototype.silentEmit.call(this, "error", error);
+        const epoch = this.connectionEpoch;
+        const timer = setTimeout(() => {
+          this.shardedSubscriberRetryTimers.delete(timer);
+          if (
+            epoch !== this.connectionEpoch ||
+            this.status === "disconnecting" ||
+            this.status === "close" ||
+            this.status === "end"
+          ) {
+            return;
+          }
+          this.refreshSlotsCache(refreshSlotsCacheCallback);
+        }, delay);
+        this.shardedSubscriberRetryTimers.add(timer);
+      }
+    );
+    this.subscriberGroupEmitter.on("moved", () => {
+      this.refreshSlotsCache(refreshSlotsCacheCallback);
+    });
+    this.subscriberGroupEmitter.on("-subscriber", () => {
+      this.emit("-subscriber");
+    });
+    this.subscriberGroupEmitter.on("+subscriber", () => {
+      this.emit("+subscriber");
+    });
+    this.subscriberGroupEmitter.on("nodeError", (error, nodeKey) => {
+      this.emit("node error", error, nodeKey);
+    });
+    this.subscriberGroupEmitter.on("subscribersReady", () => {
+      this.emit("subscribersReady");
+    });
+    for (const event of ["smessage", "smessageBuffer"]) {
+      this.subscriberGroupEmitter.on(event, (...args) => {
+        this.emit(event, ...args);
+      });
+    }
   }
 
   private createScanStream(

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:js": "TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha \"test/helpers/*.ts\" \"test/unit/**/*.ts\" \"test/functional/**/*.ts\"",
     "test:cov": "nyc npm run test:js",
     "test:js:cluster": "TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha \"test/cluster/**/*.ts\"",
+    "test:js:valkey-cluster": "TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha \"test/cluster/sharded-pubsub.ts\"",
+    "test:integration:valkey-cluster": "bash test/cluster/docker-valkey/main.sh",
     "test": "npm run test:js && npm run test:tsd",
     "lint": "eslint --ext .js,.ts ./lib",
     "docs": "npx typedoc --logLevel Error --excludeExternals --excludeProtected --excludePrivate --readme none lib/index.ts",

--- a/test/cluster/docker-valkey/main.sh
+++ b/test/cluster/docker-valkey/main.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+container_name="iovalkey-valkey-cluster-test"
+image="${VALKEY_CLUSTER_IMAGE:-valkey/valkey:8.0.9}"
+
+cleanup() {
+  status=$?
+  if (( status != 0 )); then
+    echo "Valkey Cluster integration test failed; collecting diagnostics" >&2
+    docker logs "$container_name" >&2 || true
+    docker exec "$container_name" valkey-cli -p 30000 CLUSTER NODES >&2 || true
+  fi
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+  return "$status"
+}
+trap cleanup EXIT
+
+docker rm -f "$container_name" >/dev/null 2>&1 || true
+
+docker run --detach \
+  --name "$container_name" \
+  --publish 30000-30005:30000-30005 \
+  --entrypoint /bin/sh \
+  "$image" \
+  -c '
+    set -eu
+    for port in 30000 30001 30002 30003 30004 30005; do
+      mkdir -p "/data/$port"
+      valkey-server \
+        --port "$port" \
+        --bind 0.0.0.0 \
+        --protected-mode no \
+        --cluster-enabled yes \
+        --cluster-config-file "nodes.conf" \
+        --cluster-node-timeout 5000 \
+        --appendonly no \
+        --dir "/data/$port" \
+        --daemonize yes
+    done
+
+    for port in 30000 30001 30002 30003 30004 30005; do
+      until valkey-cli -p "$port" PING >/dev/null 2>&1; do sleep 0.1; done
+    done
+    valkey-cli --cluster create \
+      127.0.0.1:30000 127.0.0.1:30001 127.0.0.1:30002 \
+      127.0.0.1:30003 127.0.0.1:30004 127.0.0.1:30005 \
+      --cluster-replicas 1 --cluster-yes
+    tail -f /dev/null
+  ' >/dev/null
+
+ready=false
+for _ in $(seq 1 300); do
+  if docker exec "$container_name" valkey-cli -p 30000 CLUSTER INFO 2>/dev/null \
+    | grep -q 'cluster_state:ok'; then
+    ready=true
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ "$ready" != true ]]; then
+  echo "Valkey Cluster did not become ready" >&2
+  exit 1
+fi
+
+npm run test:js:valkey-cluster

--- a/test/cluster/sharded-pubsub.ts
+++ b/test/cluster/sharded-pubsub.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai";
+import * as calculateSlot from "cluster-key-slot";
+import { Cluster } from "../../lib";
+
+const startupNode = { host: "127.0.0.1", port: 30000 };
+const channels = ["bar", "channel-two", "foo"];
+
+function withTimeout<T>(promise: Promise<T>, timeout: number): Promise<T> {
+  let timer: NodeJS.Timeout;
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Timed out after ${timeout}ms`)),
+      timeout
+    );
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    clearTimeout(timer);
+  });
+}
+
+describe("sharded Pub/Sub against Valkey Cluster", function () {
+  this.timeout(15000);
+
+  it("delivers messages for channels owned by different primaries", async () => {
+    const subscriber = new Cluster([startupNode]);
+    const publisher = new Cluster([startupNode]);
+
+    try {
+      await Promise.all([subscriber.info(), publisher.info()]);
+
+      const channelByOwner = new Map<string, string>();
+      for (const channel of channels) {
+        const owner = subscriber["slots"][calculateSlot(channel)][0];
+        channelByOwner.set(owner, channel);
+      }
+      const selectedChannels = Array.from(channelByOwner.values());
+      expect(selectedChannels).to.have.length.greaterThan(1);
+
+      const received = new Map<string, string>();
+      const messages = new Promise<void>((resolve) => {
+        subscriber.on("smessage", (channel, message) => {
+          received.set(channel, message);
+          if (received.size === selectedChannels.length) {
+            resolve();
+          }
+        });
+      });
+
+      for (const channel of selectedChannels) {
+        await subscriber.ssubscribe(channel);
+      }
+      for (const channel of selectedChannels) {
+        await publisher.spublish(channel, `message:${channel}`);
+      }
+
+      await withTimeout(messages, 5000);
+      for (const channel of selectedChannels) {
+        expect(received.get(channel)).to.equal(`message:${channel}`);
+      }
+      expect(await subscriber.sunsubscribe()).to.equal(0);
+    } finally {
+      subscriber.disconnect();
+      publisher.disconnect();
+    }
+  });
+});

--- a/test/functional/cluster/spub_ssub.ts
+++ b/test/functional/cluster/spub_ssub.ts
@@ -1,69 +1,88 @@
 import MockServer, { getConnectionName } from "../../helpers/mock_server";
 import { expect } from "chai";
 import { Cluster } from "../../../lib";
-import * as sinon from "sinon";
-import Redis from "../../../lib/Redis";
-import { noop } from "../../../lib/utils";
+
+const SUBSCRIBER_NAME = "ioredis-cluster(ssubscriber)";
+
+function waitFor(
+  condition: () => boolean,
+  timeout = 2000,
+  interval = 10
+): Promise<void> {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (condition()) {
+        resolve();
+      } else if (Date.now() - started >= timeout) {
+        reject(new Error("Timed out waiting for condition"));
+      } else {
+        setTimeout(check, interval);
+      }
+    };
+    check();
+  });
+}
 
 describe("cluster:spub/ssub", function () {
-  it("should receive messages", (done) => {
-    const handler = function (argv) {
+  it("routes sharded subscriptions to the slot owner", async () => {
+    let subscribedPort: number;
+    const handler = (port: number) => (argv) => {
       if (argv[0] === "cluster" && argv[1] === "SLOTS") {
         return [
-          [0, 1, ["127.0.0.1", 30001]],
-          [2, 16383, ["127.0.0.1", 30002]],
+          [0, 8000, ["127.0.0.1", 30001]],
+          [8001, 16383, ["127.0.0.1", 30002]],
         ];
       }
+      if (argv[0] === "ssubscribe") {
+        subscribedPort = port;
+        return ["ssubscribe", argv[1], 1];
+      }
     };
-    const node1 = new MockServer(30001, handler);
-    new MockServer(30002, handler);
+    new MockServer(30001, handler(30001));
+    const owner = new MockServer(30002, handler(30002));
+    const subscriber = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
 
-    const options = [{ host: "127.0.0.1", port: "30001" }];
-    const ssub = new Cluster(options);
+    const message = new Promise<[string, string]>((resolve) => {
+      subscriber.once("smessage", (channel, value) => {
+        resolve([channel, value]);
+      });
+    });
 
-    ssub.ssubscribe("test cluster", function () {
-      node1.write(node1.findClientByName("ioredis-cluster(subscriber)"), [
-        "smessage",
-        "test shard channel",
-        "hi",
-      ]);
-    });
-    ssub.on("smessage", function (channel, message) {
-      expect(channel).to.eql("test shard channel");
-      expect(message).to.eql("hi");
-      ssub.disconnect();
-      done();
-    });
+    await subscriber.ssubscribe("test cluster"); // slot 14862
+    expect(subscribedPort).to.equal(30002);
+
+    const connection = owner.findClientByName(SUBSCRIBER_NAME);
+    expect(connection).to.not.equal(undefined);
+    owner.write(connection, ["smessage", "test cluster", "hi"]);
+
+    expect(await message).to.deep.equal(["test cluster", "hi"]);
+    subscriber.disconnect();
   });
 
-  it("should works when sending regular commands", (done) => {
-    const handler = function (argv) {
+  it("keeps regular commands on regular cluster connections", async () => {
+    const handler = (argv) => {
       if (argv[0] === "cluster" && argv[1] === "SLOTS") {
         return [[0, 16383, ["127.0.0.1", 30001]]];
       }
     };
     new MockServer(30001, handler);
 
-    const ssub = new Cluster([{ port: "30001" }]);
-
-    ssub.ssubscribe("test cluster", function () {
-      ssub.set("foo", "bar").then((res) => {
-        expect(res).to.eql("OK");
-        ssub.disconnect();
-        done();
-      });
-    });
+    const subscriber = new Cluster([{ port: 30001 }]);
+    await subscriber.ssubscribe("test cluster");
+    expect(await subscriber.set("foo", "bar")).to.equal("OK");
+    subscriber.disconnect();
   });
 
-  it("supports password", (done) => {
-    const handler = function (argv, c) {
+  it("passes authentication options to sharded subscribers", async () => {
+    const handler = (argv, connection) => {
       if (argv[0] === "auth") {
-        c.password = argv[1];
-        return;
+        connection.password = argv[1];
       }
       if (argv[0] === "ssubscribe") {
-        expect(c.password).to.eql("abc");
-        expect(getConnectionName(c)).to.eql("ioredis-cluster(subscriber)");
+        expect(connection.password).to.equal("abc");
+        expect(getConnectionName(connection)).to.equal(SUBSCRIBER_NAME);
+        return ["ssubscribe", argv[1], 1];
       }
       if (argv[0] === "cluster" && argv[1] === "SLOTS") {
         return [[0, 16383, ["127.0.0.1", 30001]]];
@@ -71,38 +90,172 @@ describe("cluster:spub/ssub", function () {
     };
     new MockServer(30001, handler);
 
-    const ssub = new Redis.Cluster([{ port: "30001", password: "abc" }]);
-
-    ssub.ssubscribe("test cluster", function () {
-      ssub.disconnect();
-      done();
+    const subscriber = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      redisOptions: { password: "abc" },
     });
+    await subscriber.ssubscribe("test cluster");
+    subscriber.disconnect();
   });
 
-  it("should re-ssubscribe after reconnection", (done) => {
-    new MockServer(30001, function (argv) {
+  it("unsubscribes from every sharded subscriber without channel arguments", async () => {
+    const unsubscribedPorts: number[] = [];
+    const handler = (port: number) => (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return [
+          [0, 8000, ["127.0.0.1", 30001]],
+          [8001, 16383, ["127.0.0.1", 30002]],
+        ];
+      }
+      if (argv[0] === "ssubscribe") {
+        return ["ssubscribe", argv[1], 1];
+      }
+      if (argv[0] === "sunsubscribe") {
+        unsubscribedPorts.push(port);
+        return ["sunsubscribe", null, 0];
+      }
+    };
+    new MockServer(30001, handler(30001));
+    new MockServer(30002, handler(30002));
+    const subscriber = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+
+    await subscriber.ssubscribe("bar"); // slot 5061
+    await subscriber.ssubscribe("foo"); // slot 12182
+    expect(await subscriber.sunsubscribe("bar")).to.equal(1);
+    expect(await subscriber.sunsubscribe()).to.equal(0);
+    expect(unsubscribedPorts.sort()).to.deep.equal([30001, 30002]);
+
+    subscriber.disconnect();
+  });
+
+  it("retries MOVED subscriptions on the redirected owner", async () => {
+    const subscriptions: number[] = [];
+    let moved = false;
+    const handler = (port: number) => (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return moved
+          ? [[0, 16383, ["127.0.0.1", 30002]]]
+          : [
+              [0, 8000, ["127.0.0.1", 30001]],
+              [8001, 16383, ["127.0.0.1", 30002]],
+            ];
+      }
+      if (argv[0] === "ssubscribe") {
+        subscriptions.push(port);
+        if (port === 30001) {
+          moved = true;
+          return new Error("MOVED 5061 127.0.0.1:30002");
+        }
+        return ["ssubscribe", argv[1], 1];
+      }
+    };
+    new MockServer(30001, handler(30001));
+    new MockServer(30002, handler(30002));
+    const subscriber = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+
+    await subscriber.ssubscribe("bar"); // slot 5061
+    expect(subscriptions).to.deep.equal([30001, 30002]);
+    subscriber.disconnect();
+  });
+
+  it("cleans a stale owner after MOVED while retaining its other channels", async () => {
+    let moved = false;
+    let oldOwnerUnsubscribes = 0;
+    const handler = (port: number) => (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return moved
+          ? [
+              [0, 5060, ["127.0.0.1", 30001]],
+              [5061, 5061, ["127.0.0.1", 30002]],
+              [5062, 8000, ["127.0.0.1", 30001]],
+              [8001, 16383, ["127.0.0.1", 30002]],
+            ]
+          : [
+              [0, 8000, ["127.0.0.1", 30001]],
+              [8001, 16383, ["127.0.0.1", 30002]],
+            ];
+      }
+      if (argv[0] === "ssubscribe") {
+        return ["ssubscribe", argv[1], 1];
+      }
+      if (argv[0] === "sunsubscribe") {
+        if (port === 30001 && argv[1] === "bar") {
+          oldOwnerUnsubscribes += 1;
+          if (oldOwnerUnsubscribes === 1) {
+            moved = true;
+            return new Error("MOVED 5061 127.0.0.1:30002");
+          }
+        }
+        return ["sunsubscribe", argv[1], 0];
+      }
+    };
+    new MockServer(30001, handler(30001));
+    new MockServer(30002, handler(30002));
+    const subscriber = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+
+    await subscriber.ssubscribe("bar"); // slot 5061
+    await subscriber.ssubscribe("keep0"); // slot 7717, same initial owner
+    await subscriber.ssubscribe("foo"); // slot 12182, redirected owner
+    expect(await subscriber.sunsubscribe("bar")).to.equal(2);
+    await waitFor(() => oldOwnerUnsubscribes === 2);
+
+    subscriber.disconnect();
+  });
+
+  it("does not retain a subscription when SSUBSCRIBE fails", async () => {
+    let subscriptions = 0;
+    const handler = (argv) => {
       if (argv[0] === "cluster" && argv[1] === "SLOTS") {
         return [[0, 16383, ["127.0.0.1", 30001]]];
-      } else if (argv[0] === "ssubscribe" || argv[0] === "psubscribe") {
-        return [argv[0], argv[1]];
       }
-    });
-    const client = new Cluster([{ host: "127.0.0.1", port: "30001" }]);
+      if (argv[0] === "ssubscribe") {
+        subscriptions += 1;
+        return new Error("ERR subscription failed");
+      }
+    };
+    new MockServer(30001, handler);
+    const subscriber = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
 
-    client.ssubscribe("test cluster", function () {
-      const stub = sinon
-        .stub(Redis.prototype, "ssubscribe")
-        .callsFake((channels) => {
-          expect(channels).to.eql(["test cluster"]);
-          stub.restore();
-          client.disconnect();
-          done();
-          return Redis.prototype.ssubscribe.apply(this, arguments);
-        });
-      client.once("end", function () {
-        client.connect().catch(noop);
-      });
-      client.disconnect();
-    });
+    try {
+      await subscriber.ssubscribe("bar");
+      expect.fail("SSUBSCRIBE should reject");
+    } catch (error) {
+      expect(error.message).to.equal("ERR subscription failed");
+    }
+    subscriber.refreshSlotsCache();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(subscriptions).to.equal(1);
+    subscriber.disconnect();
+  });
+
+  it("unsubscribes the previous owner when a slot moves", async () => {
+    let ownerPort = 30002;
+    const subscriptions: number[] = [];
+    const unsubscriptions: number[] = [];
+    const handler = (port: number) => (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return [[0, 16383, ["127.0.0.1", ownerPort]]];
+      }
+      if (argv[0] === "ssubscribe") {
+        subscriptions.push(port);
+        return ["ssubscribe", argv[1], 1];
+      }
+      if (argv[0] === "sunsubscribe") {
+        unsubscriptions.push(port);
+        return ["sunsubscribe", argv[1], 0];
+      }
+    };
+    new MockServer(30001, handler(30001));
+    new MockServer(30002, handler(30002));
+    const subscriber = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+
+    await subscriber.ssubscribe("test cluster");
+    expect(subscriptions).to.deep.equal([30002]);
+
+    ownerPort = 30001;
+    subscriber.refreshSlotsCache();
+    await waitFor(() => subscriptions.includes(30001));
+    expect(unsubscriptions).to.deep.equal([30002]);
+
+    subscriber.disconnect();
   });
 });

--- a/test/unit/clusters/ClusterSubscriberGroup.ts
+++ b/test/unit/clusters/ClusterSubscriberGroup.ts
@@ -1,0 +1,19 @@
+import { expect } from "chai";
+import { EventEmitter } from "events";
+import ClusterSubscriberGroup from "../../../lib/cluster/ClusterSubscriberGroup";
+
+describe("ClusterSubscriberGroup", () => {
+  it("deduplicates channels and removes equivalent buffers", () => {
+    const group = new ClusterSubscriberGroup(new EventEmitter(), {});
+
+    expect(group.addChannels([Buffer.from("channel")])).to.equal(1);
+    expect(group.addChannels([Buffer.from("channel")])).to.equal(1);
+    expect(group.removeChannels([Buffer.from("channel")])).to.equal(0);
+  });
+
+  it("rejects channels from different slots", () => {
+    const group = new ClusterSubscriberGroup(new EventEmitter(), {});
+
+    expect(group.addChannels(["foo", "bar"])).to.equal(-1);
+  });
+});


### PR DESCRIPTION
## Summary

- route `SSUBSCRIBE` and `SUNSUBSCRIBE` to the primary that owns the channel slot
- keep independent lazy sharded subscriber connections per active primary
- preserve subscriptions across topology refreshes, `MOVED` responses, reconnects, and slot migration
- support client-wide subscription counts and zero-argument `SUNSUBSCRIBE`
- clean up stale subscriptions, connections, listeners, retries, and timers
- keep classic Pub/Sub on the existing cluster subscriber

Closes #13.

## Integration coverage

Adds a dedicated `test-valkey-cluster` GitHub Actions job. It starts three Valkey primaries and three replicas from the pinned `valkey/valkey:8.0.9` image, then verifies real `SSUBSCRIBE`/`SPUBLISH` delivery for channels owned by different primaries.

The same test runs locally with:

```sh
npm run test:integration:valkey-cluster
```

## Validation

- `npm run build`
- `npm run test:tsd`
- targeted sharded Pub/Sub tests: 10 passing
- Docker Valkey Cluster integration: passing
- `npm run lint`: no errors; 12 pre-existing warnings
- full JS suite: 425 passing; the existing localhost IPv6 assertions fail on this IPv4-resolving host and cause two cascading test failures

## Upstream attribution

`ClusterSubscriberGroup` and `ShardedSubscriber` adapt work from redis/ioredis PRs [#1956](https://github.com/redis/ioredis/pull/1956), [#2013](https://github.com/redis/ioredis/pull/2013), [#2043](https://github.com/redis/ioredis/pull/2043), [#2060](https://github.com/redis/ioredis/pull/2060), and [#2090](https://github.com/redis/ioredis/pull/2090).

The implementation commit includes `Co-authored-by` attribution for David Maier, Tihomir Krasimirov Mateev, Pavel Pashov, and Hristo Temelski.
