### PR TITLE
fix: support Valkey URL schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ new Valkey({
 });
 ```
 
-You can also specify connection options as a [`redis://` URL](http://www.iana.org/assignments/uri-schemes/prov/redis) or [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss) when using [TLS encryption](#tls-options):
+You can also specify connection options with a `valkey://` URL, or use `valkeys://` when connecting with [TLS encryption](#tls-options). The compatible `redis://` and `rediss://` schemes remain supported.
 
 ```javascript
 // Connect to 127.0.0.1:6380, db 4, using password "authpassword":
-new Valkey("redis://:authpassword@127.0.0.1:6380/4");
+new Valkey("valkey://:authpassword@127.0.0.1:6380/4");
 
 // Username can also be passed via URI.
-new Valkey("redis://username:authpassword@127.0.0.1:6380/4");
+new Valkey("valkey://username:authpassword@127.0.0.1:6380/4");
 ```
 
 See [API Documentation](https://redis.github.io/iovalkey/index.html#RedisOptions) for all available options.
@@ -861,10 +861,10 @@ const valkey = new Valkey({
 });
 ```
 
-Alternatively, specify the connection through a [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss).
+Alternatively, use a `valkeys://` URL. The compatible `rediss://` scheme is also supported.
 
 ```js
-const valkey = new Valkey("rediss://valkey.my-service.com");
+const valkey = new Valkey("valkeys://valkey.my-service.com");
 ```
 
 If you do not want to use a connection string, you can also specify an empty `tls: {}` object:

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -743,7 +743,7 @@ class Redis extends Commander implements DataHandledable {
         defaults(options, arg);
       } else if (typeof arg === "string") {
         defaults(options, parseURL(arg));
-        if (arg.startsWith("rediss://")) {
+        if (/^(?:rediss|valkeys):\/\//i.test(arg)) {
           isTls = true;
         }
       } else if (typeof arg === "number") {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -198,8 +198,15 @@ export function optimizeErrorStack(
   return error;
 }
 
+const DATABASE_URL_PROTOCOLS = new Set([
+  "redis:",
+  "rediss:",
+  "valkey:",
+  "valkeys:",
+]);
+
 /**
- * Parse the redis protocol url
+ * Parse a Redis or Valkey protocol URL.
  */
 export function parseURL(url: string): Record<string, unknown> {
   if (isInt(url)) {
@@ -219,7 +226,7 @@ export function parseURL(url: string): Record<string, unknown> {
   }
 
   if (parsed.pathname.length > 1) {
-    if (parsed.protocol === "redis:" || parsed.protocol === "rediss:") {
+    if (DATABASE_URL_PROTOCOLS.has(parsed.protocol)) {
       result.db = parsed.pathname.slice(1);
     } else {
       result.path = parsed.pathname;

--- a/test/functional/tls.ts
+++ b/test/functional/tls.ts
@@ -36,6 +36,37 @@ describe("tls option", () => {
         redis.on("end", () => done());
       });
     });
+
+    it("supports valkeys:// URLs", async () => {
+      // @ts-expect-error
+      const stub = sinon.stub(tls, "connect").callsFake((op) => {
+        // @ts-expect-error
+        expect(op.host).to.eql("localhost");
+        // @ts-expect-error
+        expect(op.port).to.eql(6379);
+        const stream = net.createConnection(op);
+        stream.on("connect", (data) => {
+          stream.emit("secureConnect", data);
+        });
+        return stream;
+      });
+
+      const redis = new Redis("valkeys://localhost:6379/4");
+      try {
+        await new Promise<void>((resolve, reject) => {
+          redis.once("ready", resolve);
+          redis.once("error", reject);
+        });
+        expect(redis.options.db).to.eql(4);
+      } finally {
+        const ended = new Promise<void>((resolve) =>
+          redis.once("end", resolve)
+        );
+        redis.disconnect();
+        await ended;
+        stub.restore();
+      }
+    });
   });
 
   describe("Sentinel", () => {

--- a/test/unit/redis.ts
+++ b/test/unit/redis.ts
@@ -98,6 +98,27 @@ describe("Redis", () => {
         });
         expect(option.tls).to.deep.equal({ hostname: "example.test" });
 
+        option = getOption("valkey://:authpassword@127.0.0.1:6380/4");
+        expect(option).to.include({
+          host: "127.0.0.1",
+          port: 6380,
+          password: "authpassword",
+          db: 4,
+        });
+
+        option = getOption("valkeys://example.test:6380/4");
+        expect(option).to.include({
+          host: "example.test",
+          port: 6380,
+          db: 4,
+          tls: true,
+        });
+
+        option = getOption("valkeys://example.test", {
+          tls: { hostname: "example.test" },
+        });
+        expect(option.tls).to.deep.equal({ hostname: "example.test" });
+
         option = getOption("redis://localhost?family=6");
         expect(option).to.have.property("family", 6);
       } catch (err) {

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -194,6 +194,24 @@ describe("utils", () => {
         password: "pass",
         key: "value",
       });
+      expect(
+        utils.parseURL("valkey://user:pass@127.0.0.1:6380/4?key=value")
+      ).to.eql({
+        host: "127.0.0.1",
+        port: "6380",
+        db: "4",
+        username: "user",
+        password: "pass",
+        key: "value",
+      });
+      expect(utils.parseURL("valkeys://[::1]:6380/2")).to.eql({
+        host: "::1",
+        port: "6380",
+        db: "2",
+      });
+      expect(utils.parseURL("valkey://127.0.0.1/")).to.eql({
+        host: "127.0.0.1",
+      });
       expect(utils.parseURL("redis://127.0.0.1/?family=6")).to.eql({
         host: "127.0.0.1",
         family: 6,


### PR DESCRIPTION
## Summary

- parse `valkey://` and `valkeys://` database paths like their Redis-compatible equivalents instead of treating them as Unix socket paths
- enable TLS for `valkeys://` while preserving explicit TLS options
- document the Valkey URL schemes and retained `redis://` / `rediss://` compatibility
- add URL parsing, constructor, and TLS transport regression coverage

This also implements the complete URL parsing and test coverage requested by #33.

## Validation

- `npm run build`
- `npm run lint` (passes with the existing warnings)
- focused unit and TLS tests: 33 passing
- `npm test`: 434 passing, including package export and `tsd` checks
- Prettier check for the changed test and utility files

Fixes #63
